### PR TITLE
Only allow portrait orientation

### DIFF
--- a/scaffold/src/main/AndroidManifest.xml
+++ b/scaffold/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:label="@string/app_name">
         <activity
             android:name=".MainActivity"
+            android:screenOrientation="portrait"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
We should probably default to portrait orientation so apps don't have janky re-layouts when the phone gets rotated.
