### PR TITLE
Updating to remove .address from plugin params.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,14 +1,14 @@
 require([
     'astro',
     'bluebird',
-    'plugins/applicationPlugin',
+    'application',
     'plugins/webViewPlugin',
     'plugins/anchoredLayoutPlugin'
 ],
 function(
     Astro,
     Promise,
-    ApplicationPlugin,
+    Application,
     WebViewPlugin,
     AnchoredLayoutPlugin
 ) {
@@ -17,7 +17,6 @@ function(
     var baseUrl = 'http://www.google.com/';
 
     // Initialize plugins
-    var applicationPromise = ApplicationPlugin.init();
     var mainWebViewPromise = WebViewPlugin.init();
     var layoutPromise = AnchoredLayoutPlugin.init();
 
@@ -28,16 +27,16 @@ function(
 
     // Use the mainWebView as the main content view for our layout
     Promise.join(layoutPromise, mainWebViewPromise, function(layout, mainWebView) {
-        layout.setContentView(mainWebView.address);
+        layout.setContentView(mainWebView);
     });
 
     // Route all unhandled key presses to the mainWebView
-    Promise.join(applicationPromise, mainWebViewPromise, function(application, mainWebView){
-        application.setMainInputPlugin(mainWebView.address);
+    mainWebViewPromise.then(function(mainWebView) {
+        Application.setMainInputPlugin(mainWebView);
     });
 
-    Promise.join(applicationPromise, layoutPromise, function(application, layout) {
-        application.setMainViewPlugin(layout.address);
+    layoutPromise.then(function(layout) {
+        Application.setMainViewPlugin(layout);
     });
 
 }, undefined, true);

--- a/app/config.js
+++ b/app/config.js
@@ -1,11 +1,12 @@
 require.config({
     baseUrl: '.',
     paths: {
-    	'astro': '../node_modules/astro-sdk/js/src/astro',
-      'app': '../node_modules/astro-sdk/js/src/app',
+        'astro': '../node_modules/astro-sdk/js/src/astro',
+        'application': '../node_modules/astro-sdk/js/src/application',
+        'worker': '../node_modules/astro-sdk/js/src/worker',
     	'plugin-manager': '../node_modules/astro-sdk/js/src/plugin-manager',
     	'plugins': '../node_modules/astro-sdk/js/src/plugins',
     	'vendor/backbone-events': '../node_modules/astro-sdk/js/vendor/backbone-events',
-      'bluebird': 'node_modules/bluebird/js/browser/bluebird'
+        'bluebird': 'node_modules/bluebird/js/browser/bluebird'
     }
 });

--- a/scaffold/src/main/java/com/mobify/astro/scaffold/MainActivity.java
+++ b/scaffold/src/main/java/com/mobify/astro/scaffold/MainActivity.java
@@ -3,20 +3,22 @@ package com.mobify.astro.scaffold;
 import android.os.Bundle;
 
 import com.mobify.astro.AstroActivity;
-import com.mobify.astro.plugins.ApplicationPlugin;
+import com.mobify.astro.plugins.AnimationPlugin;
 import com.mobify.astro.plugins.AnchoredLayoutPlugin;
-import com.mobify.astro.plugins.headerbarplugin.HeaderBarPlugin;
+import com.mobify.astro.plugins.AstroWorker;
+import com.mobify.astro.plugins.loaders.DefaultLoaderPlugin;
+import com.mobify.astro.plugins.loaders.FourDotsLoaderPlugin;
+import com.mobify.astro.plugins.ImageViewPlugin;
+import com.mobify.astro.plugins.HeaderBarPlugin;
 import com.mobify.astro.plugins.ModalViewPlugin;
-import com.mobify.astro.plugins.SplashScreenPlugin;
 import com.mobify.astro.plugins.webviewplugin.WebViewPlugin;
-import com.mobify.astro.plugins.AstroWorkerPlugin;
 import com.mobify.astro.plugins.DeviceNetworkPlugin;
 import com.mobify.astro.plugins.DrawerPlugin;
 
 import org.apache.cordova.CordovaWebView;
 
 public class MainActivity extends AstroActivity {
-    protected AstroWorkerPlugin worker;
+    protected AstroWorker worker;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -24,19 +26,19 @@ public class MainActivity extends AstroActivity {
 
         // Register plugins.
         // TODO: In the future we probably want to load this from a configuration file.
-        pluginManager.register(AstroWorkerPlugin.class);
         pluginManager.register(DeviceNetworkPlugin.class);
         pluginManager.register(DrawerPlugin.class);
         pluginManager.register(WebViewPlugin.class);
         pluginManager.register(AnchoredLayoutPlugin.class);
-        pluginManager.register(SplashScreenPlugin.class);
-        pluginManager.register(ApplicationPlugin.class);
         pluginManager.register(ModalViewPlugin.class);
         pluginManager.register(HeaderBarPlugin.class);
+        pluginManager.register(AnimationPlugin.class);
+        pluginManager.register(ImageViewPlugin.class);
+        pluginManager.register(DefaultLoaderPlugin.class);
+        pluginManager.register(FourDotsLoaderPlugin.class);
 
         // Create the initial worker.
-        worker = new AstroWorkerPlugin(this);
-        pluginManager.addPluginToInstanceList(worker);
+        worker = new AstroWorker(this);
 
         // Enable Cordova plugins by associating the worker's Cordova webview with the activity.
         CordovaWebView webView = (CordovaWebView)worker.getView();


### PR DESCRIPTION
Pass in plugin instead of pluging address to an rpc call which references another plugin by it's address

Status: **Opened for visibility**

Reviewers: @noahadams @jvaill @MikeKlemarewski @jansepar @jeremywiebe @dnerdy 
JIRA: https://mobify.atlassian.net/browse/HYB-238
Linked PRs: https://github.com/mobify/astro/pull/135
https://github.com/mobify/astro-tutorial/pull/21
https://github.com/mobify/astro-tutorial/pull/22
https://github.com/mobify/BTR-Astro/pull/10
## Changes
- Update app.js to remove .address from plugin method calls
## How to test-drive this PR
- Run the app with updated method calls in the plugins
## Research resources
- None
