### PR TITLE
Exclude nightwatch-config.js from attempting to run as an empty test

### DIFF
--- a/app/tests/system/nightwatch-config.js
+++ b/app/tests/system/nightwatch-config.js
@@ -38,7 +38,8 @@ module.exports = {
                 "platformName": "iOS",
                 "platformVersion": "8.4",
                 "deviceName": "iPhone 6"
-            }
+            },
+            "exclude": "nightwatch-config.js"
         },
 
         "ios-sim": {


### PR DESCRIPTION
Nightwatch tries to run .js files in the system folder and subfolders. We need to exclude this file so that it does not attempt to run as an empty test (shows up as an empty header in the log, does not affect actual tests).

Status: **Opened for review**
Reviewers: *\* @MikeKlemarewski @jvaill @jansepar  **
## Changes
- Exclude nightwatch-config.js from itself
## Notes
- This does not negatively affect tests in the current form, just cleans up the output logs
## How to Test
- Checkout this repo
- Run `npm install -g appium`
- `cd app; npm install`
- From the root directory of the scaffold run `npm test`
- Xcode should build the app, and appium should run a basic test.
- You should not see "Nightwatch-config.js Test Suite" in the console output and tests should pass
