### PR TITLE
Turn on embedded content contains swift flag.

### DIFF
--- a/ios/scaffold.xcodeproj/project.pbxproj
+++ b/ios/scaffold.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(CONFIGURATION_BUILD_DIR)",
@@ -430,6 +431,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(CONFIGURATION_BUILD_DIR)",


### PR DESCRIPTION
Apps submitted to the App Store that contain libraries written in Swift must have a "SwiftSupport" folder in them. Xcode will create this automatically when the `EMBEDDED_CONTENT_CONTAINS_SWIFT` build option is enabled. This PR enables that flag for the Scaffold.

Reviewers: @kschmidtdev @jvoll @jansepar 
JIRA: N/A
Linked PRs: N/A
## Changes
- Enabled `EMBEDDED_CONTENT_CONTAINS_SWIFT` flag
## How to test-drive this PR
- Select "iOS Device" (assuming no physical device connected)
- Select Product -> Archive from the menu
- Wait.... :hourglass: 
- When the Organizer window opens right-click on the new Archive and select "Show in Finder"
- Right-click on the .xcarchive file and select "Show Package Contents"
- Verify that the package contains a `SwiftSupport` folder at the root
## Research resources
- https://github.com/nomad/shenzhen
## TODOS:
- [x] ~~Update documentation in github~~
- [x] ~~Preview the docs to make sure your changes look good (see [here](https://github.com/mobify/astro#documentation) for instructions on how to preview)~~
- [x] ~~Tests have been written~~
- [x] ~~Tests are passing on CircleCI~~
- [x] ~~Change works in both Android and iOS~~
- [x] ~~CHANGELOG.md has been updated~~
- [x] ~~Update the scaffold if necessary.~~
- [x] ~~Sandbox is working. If a new feature was added, it was added to the Sandbox app)~~
