### PR TITLE
Remove cask installation commands since brew update already installs it

### DIFF
--- a/circle/install-android-dependencies.sh
+++ b/circle/install-android-dependencies.sh
@@ -2,8 +2,6 @@
 
 MYDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-brew tap caskroom/cask &&
-brew install brew-cask &&
 brew cask install java &&
 brew install android-sdk &&
 pushd $ANDROID_HOME &&


### PR DESCRIPTION
Fix build by removing cask install commands

Reviewers: **anyone**
Linked PRs: **(links to corresponding PRs, optional)**
## Changes
- Fix build by removing cask install commands, because brew update ends up installing cask anyways
## How to test-drive this PR
- Create a new branch, and update circle.yml to do a complete build on that branch (currently it only does on develop)
- Observe the build completing successfully
## TODOS:

~~\- [ ] Update documentation in github~~
~~\- [ ] Preview the docs to make sure your changes look good (see [here](https://github.com/mobify/astro#documentation) for instructions on how to preview)~~
~~\- [ ] Deploy the updated docs~~
~~\- [ ] Tests have been written~~
- [x] Tests are passing on CircleCI

~~\- [ ] Change works in both Android and iOS~~
~~\- [ ] CHANGELOG.md has been updated~~
~~\- [ ] Update the scaffold if necessary~~
~~\- [ ] Sandbox is working. If a new feature was added, it was added to the Sandbox app)~~
