### PR TITLE
Update bundle version every time we re-sign the app

### DIFF
--- a/circle/build-and-upload-ios.sh
+++ b/circle/build-and-upload-ios.sh
@@ -134,6 +134,9 @@ function resignApp() {
     rm -f "$PAYLOAD_APP_PATH/embedded.mobileprovision"
     cp "$PROVISIONING_PROFILE" "$PAYLOAD_APP_PATH/embedded.mobileprovision"
 
+    # Update bundle version
+    /usr/libexec/PlistBuddy "$PAYLOAD_APP_PATH/Info.plist" -c "Set :CFBundleVersion $BUNDLE_VERSION"
+    
     # Fix entitlements
     ENTITLEMENTS_FILE="$WORKING_DIR/entitlements.plist"
     NEW_ENTITLEMENTS_FILE=$(mktemp -t entitlements.plist)


### PR DESCRIPTION
Updates the bundle version each time we re-bundle/re-sign the app. If we don't do this, every app within a given build-and-upload-ios.sh run will have the same version.

Reviewers: @kschmidtdev 
JIRA: https://mobify.atlassian.net/browse/HYB-532
Linked PRs: N/A
## Changes
- Uses `PlistBuddy` to update the Info.plist's CFBundleVersion whenever we re-bundle/re-sign the app, as a config may customize the bundle version (ie. prefix with "CI" or something).
## How to test-drive this PR
- To fully test this you'd need to generate a new app using the Astro generator script and then follow these directions:
- Add a new config in `circle/config` that prefixes the BUNDLE_VERSION variable differently. Eg.

``` bash
BUNDLE_VERSION=ZZ$CIRCLE_BUILD_NUM
```
- Update circle.yml to build both the `circle/config/mobify-qa-ios` config and the new config by adding it to the `circle/build-and-upload-ios.sh` call
- Download the build from HockeyApp (.ipa)
- Unzip it and then open Info.plist in the .app's directory
- The CFBundleVersion should be prefixed with "ZZ" and then the build number

**OR**
Check out this build from ThinkGeek where I prefixed the CFBundleVersion with "1." https://circleci.com/gh/mobify/thinkgeek-ios/2313#artifacts
## Research resources
- None
## TODOS:

~~\- [ ] Update documentation in github~~
~~\- [ ] Preview the docs to make sure your changes look good (see [here](https://github.com/mobify/astro#documentation) for instructions on how to preview)~~
~~\- [ ] Deploy the updated docs~~
~~\- [ ] Update the [API feature parity spreadsheet](https://docs.google.com/spreadsheets/d/1bQTjiInDM4A1glbLo_CI3FYx6iW3sfL0ykcz8tVRSkw/edit#gid=0)~~
~~\- [ ] Tests have been written~~
~~\- [ ] Tests are passing on CircleCI~~
~~\- [ ] Change works in both Android and iOS~~
~~\- [ ] CHANGELOG.md has been updated~~
~~\- [ ] Update the scaffold if necessary~~
~~\- [ ] Sandbox is working. If a new feature was added, it was added to the Sandbox app)~~
