### PR TITLE
Allow XHRs to access external resources over https.

### DIFF
--- a/ios/Cordova/www/index.html
+++ b/ios/Cordova/www/index.html
@@ -28,7 +28,7 @@
             * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
                 * Enable inline JS: add 'unsafe-inline' to default-src
         -->
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: astro: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: astro: https://ssl.gstatic.com https: 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *">
         <title>Hello World</title>
     </head>
     <body>


### PR DESCRIPTION
Update the content security policy to allow connections over https.

Reviewers: **astro team**
## Changes
- Enable https for XHR in the Cordova content security policy setting
## How to test-drive this PR
- Use an XHR to access an external resource over https://
## TODOS:

~~\- [ ] Update documentation in github~~
~~\- [ ] Preview the docs to make sure your changes look good (see [here](https://github.com/mobify/astro#documentation) for instructions on how to preview)~~
~~\- [ ] Deploy the updated docs~~
~~\- [ ] Tests have been written~~
~~\- [ ] Tests are passing on CircleCI~~
- [x] Change works in both Android and iOS

~~\- [ ] CHANGELOG.md has been updated~~
- [x] Update the scaffold if necessary

~~\- [ ] Sandbox is working. If a new feature was added, it was added to the Sandbox app)~~
