### PR TITLE
Update Astro to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Mobify",
   "dependencies": {
     "bluebird": "~2.9.24",
-    "astro-sdk": "^0.7.0"
+    "astro-sdk": "^0.7.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Just updating Astro to 0.7.1 (removes grunt-harp dependency).