### PR TITLE
Update nightwatch-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ DerivedData
 ### Swift ###
 *.hmap
 *.ipa
+
+### Test Reports ###
+reports
+screenshots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## To be released
-- Updates to automated system test config and scripts.
+- Added automated system tests
 
 ## v0.7.1
 - Astro no longer uses grunt-harp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## To be released
+- Updates to automated system test config and scripts.
 
 ## v0.7.1
 - Astro no longer uses grunt-harp

--- a/README.md
+++ b/README.md
@@ -97,10 +97,7 @@ To run the tests, execute the following command from the root directory of the r
 
 ### Specify Test Device Version
 
-To specify the version you want to test against, edit the `scripts/ios-appium.sh` script and
-change the `-destination` argument to point at the desired device and version. You must also
-update the `nightwatch-config.js` file inside of `app/tests/system`. Make sure the desired capabilities
-of the nightwatch config file match the device version you specify in the bash script.
+To specify the version you want to test against, edit the `scripts/ios-appium.sh` script and specify the desired iOS device and version. These values will then be used as desired capabilities in the `nightwatch-config.js` file inside of `app/tests/system`. 
 
 # CircleCI Setup:
 - (iOS only) Update the files in `circle/certificates` and `circle/provisioning-profiles` if you have non-Mobify certificates and provision profiles.

--- a/app/tests/system/assertions/home.js
+++ b/app/tests/system/assertions/home.js
@@ -1,7 +1,7 @@
 /*
  Place commonly used assertions here.
 
- Use selectors from the equivalent page object. 
+ Use selectors from the equivalent page object.
 */
 
 var Home = require('../pageObjects/home');
@@ -9,11 +9,11 @@ var Home = require('../pageObjects/home');
 var home;
 var selectors;
 
-function HomeAssertions(browser) {
+var HomeAssertions = function(browser) {
     this.browser = browser;
     home = new Home(browser);
     selectors = home.selectors;
-}
+};
 
 HomeAssertions.prototype.assertElements = function() {
     this.browser

--- a/app/tests/system/nightwatch-config.js
+++ b/app/tests/system/nightwatch-config.js
@@ -1,10 +1,18 @@
 var path = require('path');
-var appPath = path.join(process.cwd(), '../ios/build/Build/Products/Debug-iphonesimulator/scaffold.app');
-var apkPath = path.join(process.cwd(), '../android/scaffold/build/outputs/apk/scaffold-debug.apk');
+// Customize these for your project.
+var appPath = path.join(process.cwd(), '../ios/build/Build/Products/Release-iphonesimulator/scaffold.app');
+var apkPath = path.join(process.cwd(), '../android/scaffold/build/outputs/apk/scaffold-release.apk');
+var reportsPath = process.env.CIRCLE_TEST_REPORTS || './tests/reports';
+var screenshotsPath = process.env.CIRCLE_ARTIFACTS || './tests/screenshots';
+var appPackage = 'com.mobify.astro.scaffold';
+
+// Device desired capabilities 
+var iOSVersion = '9.2';
+var androidDeviceName = 'DEVICE_NAME';
 
 module.exports = {
     'src_folders': ['./tests/system'],
-    'output_folder': '${CIRCLE_TEST_REPORTS}',
+    'output_folder': reportsPath,
     'custom_commands_path': './node_modules/nightwatch-commands/commands',
     'custom_assertions_path': './node_modules/nightwatch-commands/assertions',
 
@@ -33,13 +41,13 @@ module.exports = {
             'output': true,
             'screenshots': {
                 'enabled': true,
-                'path': '${CIRCLE_ARTIFACTS}',
+                'path': screenshotsPath,
                 'on_failure': true
             },
             'desiredCapabilities': {
                 'app': appPath,
                 'platformName': 'iOS',
-                'platformVersion': '9.2',
+                'platformVersion': iOSVersion,
                 'deviceName': 'iPhone 6'
             },
             'exclude': ['nightwatch-config.js', 'pageObjects', 'assertions']
@@ -50,8 +58,8 @@ module.exports = {
                 'app': apkPath,
                 'platformName': 'Android',
                 'platformVersion': '',
-                'deviceName': 'DEVICE NAME',
-                'appPackage': 'com.mobify.astro.scaffold',
+                'deviceName': androidDeviceName,
+                'appPackage': appPackage,
                 'browserName': '',
                 'recreateChromeDriverSessions': true
             }

--- a/app/tests/system/nightwatch-config.js
+++ b/app/tests/system/nightwatch-config.js
@@ -7,7 +7,8 @@ var screenshotsPath = process.env.CIRCLE_ARTIFACTS || './tests/screenshots';
 var appPackage = 'com.mobify.astro.scaffold';
 
 // Device desired capabilities 
-var iOSVersion = '9.2';
+var iOSVersion = process.env.IOS_VERSION || '9.2';
+var iOSDeviceName = process.env.IOS_DEVICE_NAME || 'iPhone 6';
 var androidDeviceName = 'DEVICE_NAME';
 
 module.exports = {
@@ -48,7 +49,7 @@ module.exports = {
                 'app': appPath,
                 'platformName': 'iOS',
                 'platformVersion': iOSVersion,
-                'deviceName': 'iPhone 6'
+                'deviceName': iOSDeviceName
             },
             'exclude': ['nightwatch-config.js', 'pageObjects', 'assertions']
         },

--- a/app/tests/system/nightwatch-config.js
+++ b/app/tests/system/nightwatch-config.js
@@ -6,7 +6,7 @@ var reportsPath = process.env.CIRCLE_TEST_REPORTS || './tests/reports';
 var screenshotsPath = process.env.CIRCLE_ARTIFACTS || './tests/screenshots';
 var appPackage = 'com.mobify.astro.scaffold';
 
-// Device desired capabilities 
+// Device desired capabilities
 var iOSVersion = process.env.IOS_VERSION || '9.2';
 var iOSDeviceName = process.env.IOS_DEVICE_NAME || 'iPhone 6';
 var androidDeviceName = 'DEVICE_NAME';

--- a/app/tests/system/pageObjects/home.js
+++ b/app/tests/system/pageObjects/home.js
@@ -1,9 +1,9 @@
 /*
  Put actions in this page object.
- 
+
  Do not perform verifications here. Verifications and assertions should go
- either in the test script or, for commonly used assertions, placed in an 
- assertions object in tests/system/assertions. 
+ either in the test script or, for commonly used assertions, placed in an
+ assertions object in tests/system/assertions.
 */
 
 var selectors = {

--- a/app/tests/system/pages/web/homepage.js
+++ b/app/tests/system/pages/web/homepage.js
@@ -15,7 +15,7 @@ module.exports = {
                     .url(function(url) {
                         browser.log(url.value);
                     })
-                    .assert.urlContains('google');
+                    .assert.urlContains('https://webpush-you-host.mobifydemo.io/about/');
             })
             .end();
     }

--- a/scripts/ios-appium.sh
+++ b/scripts/ios-appium.sh
@@ -25,6 +25,7 @@ pushd $ROOT/ios/
 xcodebuild \
     -workspace "scaffold.xcworkspace/" \
     -scheme "scaffold" \
+    -configuration "Release" \
     -destination "platform=iOS Simulator,name=$IOS_DEVICE_NAME,OS=$IOS_VERSION" \
     -derivedDataPath "build" \
     build | prettifyOutput

--- a/scripts/ios-appium.sh
+++ b/scripts/ios-appium.sh
@@ -4,6 +4,8 @@ set -o pipefail
  
 MYPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) 
 ROOT=$MYPATH/..
+export IOS_DEVICE_NAME="iPhone 6"
+export IOS_VERSION="9.2"
 
 # Kill background processes when this script exits.
 trap 'kill $(jobs -p)' EXIT
@@ -23,10 +25,10 @@ pushd $ROOT/ios/
 xcodebuild \
     -workspace "scaffold.xcworkspace/" \
     -scheme "scaffold" \
-    -destination "platform=iOS Simulator,name=iPhone 6,OS=8.3" \
+    -destination "platform=iOS Simulator,name=$IOS_DEVICE_NAME,OS=$IOS_VERSION" \
     -derivedDataPath "build" \
     build | prettifyOutput
 popd
 
 pushd $ROOT/app/
-grunt nightwatch -e ios-sim
+grunt nightwatch


### PR DESCRIPTION
Updates the system test configuration `nightwatch-config.js` to make it more better :) 

JIRA: https://mobify.atlassian.net/browse/CSOG-44
Linked PRs: Acts on feedback from https://github.com/mobify/astro-scaffold/pull/62

## Changes
- Test against `release` apps and apks. 
- Test reports and screenshots can be saved to a local directory (with an appropriate name) when running tests locally, or saved to the appropriate CircleCI directories when running on CircleCI
- iOS device settings (name, OS version) are set in the build and test script `ios-appium.sh` and exported to be used in `nightwatch-config.js`
- Fix linting errors.

## How to test-drive this PR
- Clone https://github.com/mobify/generator-astro
- Change `generator.sh`:
```
SCAFFOLD_VERSION="nightwatch-config"
SCAFFOLD_URL="https://github.com/mobify/astro-scaffold/archive/nightwatch-config.zip"
```
- Run `./generator.sh`
- `cd` into generated project and run `./scripts/ios-appium.sh`

## TODOS:
- [x] Tests are passing on your machine.
- [x] Change works in both Android and iOS. (Tested with iOS build and test script. Not sure if there's an equivalent for Android). 
- [x] CHANGELOG.md has been updated.
- [x] Scaffold is working. If a new feature was added, it was added to the Scaffold app.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from QA @lilyzh 
- [x] +1 from an engineer on the Astro team. @jvoll @jeremywiebe 
