### PR TITLE
HYB-669: Update the docs to tell the developer that the first build will take quite a while

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To get up and running with scaffold, ensure the dependencies are installed:
 
     npm install
 
-During the first build in Xcode or Android Studio, the npm dependencies for astro-sdk are installed. This takes some time, so you can do them manually:
+During the first build in Xcode or Android Studio, the npm dependencies for astro-sdk are installed. This takes some time, so you can install them manually:
 
     pushd node_modules/astro-sdk && npm install && popd
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ During the first build in Xcode or Android Studio, the npm dependencies for astr
 
     pushd node_modules/astro-sdk && npm install && popd
 
-
 **Note**: The `app/build-js.sh` script automatically builds app.js.
 If node.js isn't installed to /usr/local/bin, run:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ To get up and running with scaffold, ensure the dependencies are installed:
 
     npm install
 
+During the first build in Xcode or Android Studio, the npm dependencies for astro-sdk are installed. This takes some time, so you can do them manually:
+
+    pushd node_modules/astro-sdk && npm install && popd
+
+
 **Note**: The `app/build-js.sh` script automatically builds app.js.
 If node.js isn't installed to /usr/local/bin, run:
 


### PR DESCRIPTION
Added documentation for how to avoid a slow first-time build experience

JIRA: **https://mobify.atlassian.net/browse/HYB-669**

## Changes
- Added documentation for how to avoid a slow first-time build experience

## How to test-drive this PR
- `git clone` the astro-scaffold (or generate a new project)
- `git clean -fdx` (if you already had the scaffold cloned)
- Go through the updated docs, `npm install`-ing for astro-sdk as well
- Build the app in Xcode, observe it isn't brutally slow the first time

## TODOS:
- [x] Update README.md