### PR TITLE
Updating back behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## To be released
+- Update to use backButtonPressed event and ensure application closes at appropriate times in Android.
 - Added automated system tests
 
 ## v0.7.1

--- a/app/app.js
+++ b/app/app.js
@@ -64,7 +64,7 @@ window.run = function() {
                 Application.setMainViewPlugin(drawerController.drawer);
 
                 // Wiring up the hardware back button for Android
-                Application.on('onKeyDown', function(params) {
+                Application.on('backButtonPressed', function() {
                     drawerController.backActiveItem();
                 });
 

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -24,8 +24,8 @@ fi
 pushd ../node_modules/astro-sdk
 npm install
 grunt build_astro_client
-cp js/build/astro-client.js ../../app/scaffold-www/
 popd
+cp ../node_modules/astro-sdk/js/build/astro-client.js scaffold-www/
 
 # Build app.js.
 grunt build

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -24,8 +24,8 @@ fi
 pushd ../node_modules/astro-sdk
 npm install
 grunt build_astro_client
+cp js/build/astro-client.js $MYPATH/scaffold-www/
 popd
-cp ../node_modules/astro-sdk/js/build/astro-client.js scaffold-www/
 
 # Build app.js.
 grunt build

--- a/app/scaffold-controllers/navigationController.js
+++ b/app/scaffold-controllers/navigationController.js
@@ -1,5 +1,6 @@
 define([
     'bluebird',
+    'application',
     'plugins/anchoredLayoutPlugin',
     'plugins/navigationPlugin',
     'scaffold-controllers/navigationHeaderController'
@@ -7,6 +8,7 @@ define([
 /* eslint-disable */
 function(
     Promise,
+    Application,
     AnchoredLayoutPlugin,
     NavigationPlugin,
     NavigationHeaderController
@@ -88,7 +90,14 @@ function(
     };
 
     NavigationController.prototype.back = function() {
-        this.navigationView.back();
+        var self = this;
+        self.navigationView.canGoBack().then(function(canGoBack) {
+            if (canGoBack) {
+                self.navigationView.back();
+            } else {
+                Application.closeApp();
+            }
+        });
     };
 
     return NavigationController;

--- a/app/scaffold-www/astro-client.js
+++ b/app/scaffold-www/astro-client.js
@@ -5381,6 +5381,16 @@ module.exports = ret;
         var iframeID = 'astro-bridge-frame';
 
         var notify = function() {
+            // We insert the notifying iframe into body (it's not a good
+            // idea to put iframes into head). But, if someone was to
+            // put `astro-client.js` and a bunch of Astro.trigger calls
+            // in the <head>, we need to make sure we wait until body
+            // is available.
+            if (!window.document.body) {
+                setTimeout(notify, 100);
+                return;
+            }
+
             // Ensure that the bridge exists and hasn't been removed from the document
             if (!document.getElementById(iframeID)) {
                 iframe = document.createElement('iframe');


### PR DESCRIPTION
Update back behaviour with new back event

JIRA: https://mobify.atlassian.net/browse/HYB-682
Linked PRs: https://github.com/mobify/astro/pull/420

## Changes
- Listen on `backButtonPressed` instead of `onKeyDown`
- Close app if NavigationPlugin can't go back
- I had trouble running the build-js.sh...it couldn't find `../../app/scaffold-www/` when I pointed to a local verison of astro. Changed the copy command so that it worked on my setup.

## How to test-drive this PR
- npm link to newest version of Astro develop
- Navigate forward in one of the sections.
- Use the hardware back button to go back through the navigation and then close the app when there are no more back navigations available

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [x] Scaffold is working. If a new feature was added, it was added to the Scaffold app.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.

