### PR TITLE
Use UIWebView for appium tests until appium supports WKWebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## To be released
-- 
+- Use UIWebView for Appium tests until Appium supports WKWebView
 
 ## v0.8.0
 - Update to use backButtonPressed event and ensure application closes at appropriate times in Android.

--- a/ios/scaffold/AppDelegate.swift
+++ b/ios/scaffold/AppDelegate.swift
@@ -23,6 +23,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             AstroConfig.allowUntrustedHTTPSCertificate = true
         #endif
 
+        #if TEST
+            AstroConfig.useWKWebView = false
+        #endif
+
         astroViewController = AstroViewController(appJsUrl: NSURL(string: "app.js")!, launchOptions: launchOptions,
             pluginRegistrations: { pluginRegistrar in
         })

--- a/scripts/ios-appium.sh
+++ b/scripts/ios-appium.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -eu
 
 set -o pipefail
- 
-MYPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) 
+
+MYPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT=$MYPATH/..
 export IOS_DEVICE_NAME="iPhone 6"
 export IOS_VERSION="9.2"
@@ -28,6 +28,7 @@ xcodebuild \
     -configuration "Release" \
     -destination "platform=iOS Simulator,name=$IOS_DEVICE_NAME,OS=$IOS_VERSION" \
     -derivedDataPath "build" \
+    OTHER_SWIFT_FLAGS="\${inherited} -D TEST" \
     build | prettifyOutput
 popd
 


### PR DESCRIPTION
JIRA: **https://mobify.atlassian.net/browse/HYB-722**

## Changes
- add a flag to the appium xcodebuild script to hook onto in AppDelegate and use UIWebView for tests

## How to test-drive this PR
- run the scaffold and make sure we are using WKWebView for iOS 9+
- run the appium tests and make sure they pass (meaning they are using UIWebView)

## TODOS:
- [ ] ~~Tests have been written.~~
- [x] Tests are passing on your machine.
- [ ] ~~Change works in both Android and iOS.~~
- [x] CHANGELOG.md has been updated.
- [x] Scaffold is working. If a new feature was added, it was added to the Scaffold app.
- [ ] ~~Run the generator to make sure it still functions correctly.~~
- [ ] +1 from an engineer on the Astro team.

