### PR TITLE
Fix Android build variants

### DIFF
--- a/android/.idea/modules.xml
+++ b/android/.idea/modules.xml
@@ -4,7 +4,6 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/android.iml" filepath="$PROJECT_DIR$/android.iml" />
       <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" />
-      <module fileurl="file://$PROJECT_DIR$/../astro/android/astro.iml" filepath="$PROJECT_DIR$/../astro/android/astro.iml" />
       <module fileurl="file://$PROJECT_DIR$/scaffold/scaffold.iml" filepath="$PROJECT_DIR$/scaffold/scaffold.iml" />
     </modules>
   </component>

--- a/android/scaffold/build.gradle
+++ b/android/scaffold/build.gradle
@@ -16,6 +16,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            testCoverageEnabled true
+        }
     }
 }
 
@@ -28,5 +31,6 @@ preBuild.dependsOn buildJS
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.0'
-    compile project(':astro')
+    releaseCompile project(path: ':astro', configuration: 'release')
+    debugCompile project(path: ':astro', configuration: 'debug')
 }

--- a/android/scaffold/scaffold.iml
+++ b/android/scaffold/scaffold.iml
@@ -66,9 +66,11 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/coverage-instrumented-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndk" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />


### PR DESCRIPTION
Fix Android build variants and remove the reference to the pre-NPM Astro project reference

## Changes
- Remove pre-NPM Astro project reference
- Update build.gradle to synchronize debug/release
- Add Android debug test coverage so debug builds can run on device

## How to test-drive this PR
- Change the variant to debug or release, run the app

## TODOS:
~~- [ ] Change works in both Android and iOS.~~
~~- [ ] CHANGELOG.md has been updated.~~

- [x] Scaffold is working. If a new feature was added, it was added to the Scaffold app.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.

~~- [ ] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)~~

Update build.gradle so build variants are in sync