### PR TITLE
Fix `user-env.sh` generation snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If node.js isn't installed in `/usr/local/bin`, run:
 
 ```bash
 cp app/user-env.sh.example app/user-env.sh && \
-    sed -i '' '/export PATH="/d"' app/user-env.sh && \
+    sed -i '' '/export PATH="/d' app/user-env.sh && \
     echo "export PATH=\$PATH:\"$(which npm | sed 's/\/npm//')\"" >> app/user-env.sh && \
     chmod +x app/user-env.sh
 ```


### PR DESCRIPTION
Fixes the bash snippet that generates the `user-env.sh` file. The `/d` command must be the last piece of the `sed` command as it specifies to delete to the end of the line.

JIRA: N/A
Linked PRs: N/A

## Changes
- Remove closing quote in the `sed` command (not needed and breaks the command)

## How to test-drive this PR
- Run the generator
- `cd` into the newly generated project dir
- Run the bash snippet. You should see a new `app/user-env.sh` file with the path to your `npm` install

## TODOS:
~- [ ] Change works in both Android and iOS.~
-~ [ ] CHANGELOG.md has been updated.~
~- [ ] Scaffold is working. If a new feature was added, it was added to the Scaffold app.~

- [x] Run the generator to make sure it still functions correctly.
- [ ] +1 from an engineer on the Astro team.

~- [ ] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)~

