### PR TITLE
HYB-788: As an Astro Developer, I want the scaffold to work on buildbuddy out of the box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## To be released
+- Add support for buddybuild
+- Update scripts depending on a globally-installed version of grunt to use a local version (and updated package.json to install it locally)
 
 ## v0.10.1
 - Upgrade to use Android Studio 2.0

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -35,9 +35,10 @@ cp $ROOT/node_modules/jquery/dist/jquery.min.js $MYPATH/app-www/js
 # Build astro-client.js
 pushd $ROOT/node_modules/astro-sdk
 npm install
-grunt build_astro_client
+$MYPATH/node_modules/grunt-cli/bin/grunt build_astro_client
 cp js/build/astro-client.js $MYPATH/app-www/js
 popd
 
 # Build app.js.
 grunt build
+$MYPATH/node_modules/grunt-cli/bin/grunt build

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -40,5 +40,4 @@ cp js/build/astro-client.js $MYPATH/app-www/js
 popd
 
 # Build app.js.
-grunt build
 $MYPATH/node_modules/grunt-cli/bin/grunt build

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+npm install

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.1.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^13.0.0",
     "grunt-requirejs": "^0.4.2",


### PR DESCRIPTION
JIRA: **https://mobify.atlassian.net/browse/HYB-788**

## Changes
- add buddybuild_postclone.sh script
- update package.json to install grunt-cli and update scripts to use it instead of a globally-installed one

## How to test-drive this PR
- Generate a project based on this branch
- Run the buddybuild script
- Build and test on both platforms

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [x] Scaffold is working. If a new feature was added, it was added to the Scaffold app.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.

~~- [ ] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)~~