### PR TITLE
[HYB-805] iOS: Switching tabs programmatically should highlight selected tab

### DIFF
--- a/app/app-controllers/tabBarController.js
+++ b/app/app-controllers/tabBarController.js
@@ -93,10 +93,14 @@ function(
                 this.tabBar.NavigationControllers[this.activeTabId].isActive = false;
             }
 
+            // Highlight selected tab when tab switch is
+            // made programatically
+            this.tabBar.selectItem(tabId);
             this.viewPlugin.setContentView(this.tabBar.tabViews[tabId]);
+            this.activeTabId = tabId;
+
             var selectedTab = this.tabBar.NavigationControllers[tabId];
             selectedTab.isActive = true;
-            this.activeTabId = tabId;
         }
     };
 


### PR DESCRIPTION
[HYB-805] iOS: Switching tabs programmatically should highlight selected tab

JIRA: **[[HYB-805] iOS: Switching tabs programmatically should highlight selected tab](https://mobify.atlassian.net/browse/HYB-805)**
Linked PRs: **None**

## Changes
- Pulling in [fix from eXtra](https://github.com/mobify/extra-mobile/blob/61f0ddd69586376b99d2431ff29c7e17671f80d9/native/app/extra-controllers/tabBarController.js#L103) to highlight selected tab when programmatically switching tabs

## How to test-drive this PR
You can view the same changes in eXtra by following the steps:

1. Run eXtra's `develop` branch on iOS
1. Go to a PDP and add item to cart
1. Switch to a different tab
1. Open cart & tap on a product in the cart to initiate tab switch & navigation
1. Observe the first tab should be highlighted.

Or temporarily make tabBarController accessible in the Safari Console and trigger a tab switch.

## TODOS:
- ~~[ ] Change works in both Android and iOS.~~
- ~~[ ] CHANGELOG.md has been updated.~~
- [x] Scaffold is working. If a new feature was added, it was added to the Scaffold app.
- ~~[ ] Run the generator to make sure it still functions correctly.~~
- [ ] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)

