### PR TITLE
MSG-355: Include Android pushclient in app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## To be released
+- Include pushclient module in android build
 
 ## v0.12.0
 - Update app icon resource for Xcode 7

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -10,7 +10,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/scaffold" />
             <option value="$PROJECT_DIR$/../node_modules/astro-sdk/android" />
-            <option value="$PROJECT_DIR$/../node_modules/mobify-push-android-client/pushclient" />
+            <option value="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient" />
           </set>
         </option>
         <option name="myModules">
@@ -18,7 +18,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/scaffold" />
             <option value="$PROJECT_DIR$/../node_modules/astro-sdk/android" />
-            <option value="$PROJECT_DIR$/../node_modules/mobify-push-android-client/pushclient" />
+            <option value="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -10,7 +10,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/scaffold" />
             <option value="$PROJECT_DIR$/../node_modules/astro-sdk/android" />
-            <option value="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient" />
+            <option value="$PROJECT_DIR$/../node_modules/mobify-push-android-client/pushclient" />
           </set>
         </option>
         <option name="myModules">
@@ -18,7 +18,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/scaffold" />
             <option value="$PROJECT_DIR$/../node_modules/astro-sdk/android" />
-            <option value="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient" />
+            <option value="$PROJECT_DIR$/../node_modules/mobify-push-android-client/pushclient" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -10,6 +10,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/scaffold" />
             <option value="$PROJECT_DIR$/../node_modules/astro-sdk/android" />
+            <option value="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient" />
           </set>
         </option>
         <option name="myModules">
@@ -17,6 +18,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/scaffold" />
             <option value="$PROJECT_DIR$/../node_modules/astro-sdk/android" />
+            <option value="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -1,5 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="NullableNotNullManager">
+    <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
+    <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
+    <option name="myNullables">
+      <value>
+        <list size="4">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+        </list>
+      </value>
+    </option>
+    <option name="myNotNulls">
+      <value>
+        <list size="4">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+        </list>
+      </value>
+    </option>
+  </component>
   <component name="ProjectLevelVcsManager" settingsEditedManually="false">
     <OptionsSetting value="true" id="Add" />
     <OptionsSetting value="true" id="Remove" />
@@ -10,7 +34,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/.idea/modules.xml
+++ b/android/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/android.iml" filepath="$PROJECT_DIR$/android.iml" />
       <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" />
+      <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" />
       <module fileurl="file://$PROJECT_DIR$/scaffold/scaffold.iml" filepath="$PROJECT_DIR$/scaffold/scaffold.iml" />
     </modules>
   </component>

--- a/android/.idea/modules.xml
+++ b/android/.idea/modules.xml
@@ -4,7 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/android.iml" filepath="$PROJECT_DIR$/android.iml" />
       <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" />
-      <module fileurl="file://$PROJECT_DIR$/../node_modules/mobify-push-android-client/pushclient/pushclient.iml" filepath="$PROJECT_DIR$/../node_modules/mobify-push-android-client/pushclient/pushclient.iml" />
+      <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" />
       <module fileurl="file://$PROJECT_DIR$/scaffold/scaffold.iml" filepath="$PROJECT_DIR$/scaffold/scaffold.iml" />
     </modules>
   </component>

--- a/android/.idea/modules.xml
+++ b/android/.idea/modules.xml
@@ -4,7 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/android.iml" filepath="$PROJECT_DIR$/android.iml" />
       <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" />
-      <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" />
+      <module fileurl="file://$PROJECT_DIR$/../node_modules/mobify-push-android-client/pushclient/pushclient.iml" filepath="$PROJECT_DIR$/../node_modules/mobify-push-android-client/pushclient/pushclient.iml" />
       <module fileurl="file://$PROJECT_DIR$/scaffold/scaffold.iml" filepath="$PROJECT_DIR$/scaffold/scaffold.iml" />
     </modules>
   </component>

--- a/android/scaffold/scaffold.iml
+++ b/android/scaffold/scaffold.iml
@@ -64,14 +64,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -80,6 +72,14 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />

--- a/android/scaffold/scaffold.iml
+++ b/android/scaffold/scaffold.iml
@@ -64,14 +64,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -80,23 +72,26 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
@@ -109,8 +104,8 @@
     <orderEntry type="library" exported="" name="moshi-1.1.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.1.0" level="project" />
     <orderEntry type="library" exported="" name="appcompat-v7-23.1.0" level="project" />
-    <orderEntry type="library" exported="" name="converter-moshi-2.0.2" level="project" />
     <orderEntry type="library" exported="" name="okio-1.6.0" level="project" />
+    <orderEntry type="library" exported="" name="converter-moshi-2.0.2" level="project" />
     <orderEntry type="library" exported="" name="okhttp-3.2.0" level="project" />
     <orderEntry type="library" exported="" name="support-v4-23.1.0" level="project" />
     <orderEntry type="library" exported="" name="retrofit-2.0.2" level="project" />

--- a/android/scaffold/scaffold.iml
+++ b/android/scaffold/scaffold.iml
@@ -88,6 +88,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
@@ -97,6 +98,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />

--- a/android/scaffold/scaffold.iml
+++ b/android/scaffold/scaffold.iml
@@ -88,7 +88,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
@@ -98,7 +97,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
@@ -106,9 +104,14 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="support-v4-23.1.0" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-23.1.0" level="project" />
+    <orderEntry type="library" exported="" name="moshi-1.1.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.1.0" level="project" />
+    <orderEntry type="library" exported="" name="appcompat-v7-23.1.0" level="project" />
+    <orderEntry type="library" exported="" name="converter-moshi-2.0.2" level="project" />
+    <orderEntry type="library" exported="" name="okio-1.6.0" level="project" />
+    <orderEntry type="library" exported="" name="okhttp-3.2.0" level="project" />
+    <orderEntry type="library" exported="" name="support-v4-23.1.0" level="project" />
+    <orderEntry type="library" exported="" name="retrofit-2.0.2" level="project" />
     <orderEntry type="module" module-name="astro" exported="" />
   </component>
 </module>

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,3 @@
 include ':scaffold', ':astro', ':astro:pushclient'
 project(':astro').projectDir = new File(settingsDir, '../node_modules/astro-sdk/android')
-project(':astro:pushclient').projectDir = new File(settingsDir, '../node_modules/mobify-push-android-client/pushclient')
+project(':astro:pushclient').projectDir = new File(settingsDir, '../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient')

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,3 @@
 include ':scaffold', ':astro', ':astro:pushclient'
 project(':astro').projectDir = new File(settingsDir, '../node_modules/astro-sdk/android')
-project(':astro:pushclient').projectDir = new File(settingsDir, '../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient')
+project(':astro:pushclient').projectDir = new File(settingsDir, '../node_modules/mobify-push-android-client/pushclient')

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,3 @@
-include ':scaffold', ':astro'
+include ':scaffold', ':astro', ':astro:pushclient'
 project(':astro').projectDir = new File(settingsDir, '../node_modules/astro-sdk/android')
+project(':astro:pushclient').projectDir = new File(settingsDir, '../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient')

--- a/package.json
+++ b/package.json
@@ -3,17 +3,17 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "git+ssh://git@github.com:mobify/astro.git#develop",
+    "astro-sdk": "git+ssh://git@github.com:mobify/astro.git#push_client_as_dependency",
     "bluebird": "~2.9.24",
     "jquery": "^2.2.2",
-    "navitron": "^1.0.0"
+    "navitron": "^1.0.0",
+    "grunt-requirejs": "^0.4.2"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^1.1.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^13.0.0",
-    "grunt-requirejs": "^0.4.2",
     "mobify-code-style": "^2.2.1",
     "nightwatch": "0.8.18",
     "nightwatch-commands": "1.5.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "~0.12.0",
+    "astro-sdk": "git+ssh://git@github.com:mobify/astro.git#msg-355-astro-implementation",
     "bluebird": "~2.9.24",
     "jquery": "^2.2.2",
     "navitron": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "git+ssh://git@github.com:mobify/astro.git#push_client_as_dependency",
+    "astro-sdk": "git+ssh://git@github.com:mobify/astro.git#develop",
     "bluebird": "~2.9.24",
     "jquery": "^2.2.2",
     "navitron": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "git+ssh://git@github.com:mobify/astro.git#msg-355-astro-implementation",
+    "astro-sdk": "git+ssh://git@github.com:mobify/astro.git#develop",
     "bluebird": "~2.9.24",
     "jquery": "^2.2.2",
     "navitron": "^1.0.0"


### PR DESCRIPTION
The Android `pushclient` module must be included in `settings.gradle` file of the app in order for the app to compile.

JIRA: https://mobify.atlassian.net/browse/MSG-355
Linked PRs: None

## Changes
- Update `settings.gradle` to include `pushclient` module
- Point package.json at develop version of astro

## How to test-drive this PR
- Build the project in Android and install the app

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [x] Scaffold is working. If a new feature was added, it was added to the Scaffold app.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)
- [x] Update the astro branch to point at develop once the astro changes have been merged

