### PR TITLE
Portrait-only and pop to root support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## To be released
 - Include pushclient module in android build
+- [iOS] set app to portrait-only
+- [iOS] implement pop-to-root
 
 ## v0.12.0
 - Update app icon resource for Xcode 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## To be released
 - Include pushclient module in android build
 - [iOS] set app to portrait-only
-- [iOS] implement pop-to-root
+- [iOS] implement pop-to-root on re-selection of currently displaying tab item
 
 ## v0.12.0
 - Update app icon resource for Xcode 7

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,6 @@ Linked PRs: **(links to corresponding PRs, optional)**
 ## TODOS:
 - [ ] Change works in both Android and iOS.
 - [ ] CHANGELOG.md has been updated.
-- [ ] Scaffold is working. If a new feature was added, it was added to the Scaffold app.
 - [ ] Run the generator to make sure it still functions correctly.
 - [ ] +1 from an engineer on the Astro team.
 - [ ] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)

--- a/app/app-controllers/navigationController.js
+++ b/app/app-controllers/navigationController.js
@@ -175,6 +175,10 @@ function(
             });
     };
 
+    NavigationController.prototype.popToRoot = function(params) {
+        return this.navigationView.popToRoot(params);
+    };
+
     NavigationController.prototype.back = function() {
         var self = this;
         self.navigationView.canGoBack().then(function(canGoBack) {

--- a/app/app-controllers/navigationController.js
+++ b/app/app-controllers/navigationController.js
@@ -158,7 +158,7 @@ function(
 
     NavigationController.prototype.navigateMainViewToNewRoot = function(url, title) {
         var self = this;
-        this.navigationView.popToRoot({animated: true})
+        this.popToRoot({animated: true})
             .then(function() {
                 return self.navigationView.getTopPlugin();
             })

--- a/app/app-controllers/tabBarController.js
+++ b/app/app-controllers/tabBarController.js
@@ -100,8 +100,7 @@ function(
             this.viewPlugin.setContentView(this.tabBar.tabViews[tabId]);
             this.activeTabId = tabId;
 
-            var selectedTab = this.tabBar.NavigationControllers[tabId];
-            selectedTab.isActive = true;
+            this.getActiveNavigationView().isActive = true;
         } else {
             this.getActiveNavigationView().popToRoot({animated: true});
         }

--- a/app/app-controllers/tabBarController.js
+++ b/app/app-controllers/tabBarController.js
@@ -87,21 +87,28 @@ function(
     };
 
     TabBarController.prototype.selectTab = function(tabId) {
+        return this.tabBar.selectItem(tabId);
+    };
+
+    TabBarController.prototype._selectTabHandler = function(tabId) {
         if (this.activeTabId !== tabId) {
             // activeTabId is undefined during startup
             if (this.activeTabId) {
-                this.tabBar.NavigationControllers[this.activeTabId].isActive = false;
+                this.getActiveNavigationView().isActive = false;
             }
 
-            // Highlight selected tab when tab switch is
-            // made programatically
-            this.tabBar.selectItem(tabId);
             this.viewPlugin.setContentView(this.tabBar.tabViews[tabId]);
             this.activeTabId = tabId;
 
             var selectedTab = this.tabBar.NavigationControllers[tabId];
             selectedTab.isActive = true;
+        } else {
+            this.getActiveNavigationView().popToRoot({animated: true});
         }
+    };
+
+    TabBarController.prototype.getActiveNavigationView = function() {
+        return this.tabBar.NavigationControllers[this.activeTabId];
     };
 
     TabBarController.prototype._bindEvents = function() {
@@ -109,7 +116,7 @@ function(
 
         // Select Tab
         this.tabBar.on('itemSelect', function(data) {
-            self.selectTab(data.id);
+            self._selectTabHandler(data.id);
         });
     };
 

--- a/ios/scaffold/Info.plist
+++ b/ios/scaffold/Info.plist
@@ -51,8 +51,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
JIRA: **https://mobify.atlassian.net/browse/HYB-786 https://mobify.atlassian.net/browse/HYB-803**

## Changes
- Set iOS app to be portrait-only (this was already true on Android)
- Implement pop-to-root support when you tap on the current tab in the tab bar controller (iOS only)
- Fix bug where selecting a tab calls the (formerly named) `selectTab` function twice (and therefore popped to root on every tab tap)
- Fixed PR template to remove "feature added to scaffold"...obviously if you are making a change to scaffold you are probably doing that and "Change works in both Android and iOS" covers that.

## How to test-drive this PR
- iOS - run the app and rotate the phone
- iOS pop to root, make sure not every tap on a tab pops to root (only should happen if you are already on the tab)
- android - make sure that back/forward navigation and drawer navigation work correctly

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [ ] Run the generator to make sure it still functions correctly.
- [ ] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)
