### PR TITLE
Include the PushClient iOS library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## To be released
 - Include pushclient module in android build
+- Include PushClient module in iOS build
 - [iOS] set app to portrait-only
 - [iOS] implement pop-to-root on re-selection of currently displaying tab item
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## To be released
+- Include pushclient module in iOS build
 
 ## v0.13.0
 - Include pushclient module in android build
-- Include pushclient module in iOS build
 - [iOS] set app to portrait-only
 - [iOS] implement pop-to-root on re-selection of currently displaying tab item
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## To be released
 - Include pushclient module in android build
-- Include PushClient module in iOS build
+- Include pushclient module in iOS build
 - [iOS] set app to portrait-only
 - [iOS] implement pop-to-root on re-selection of currently displaying tab item
 

--- a/ios/scaffold.xcodeproj/project.pbxproj
+++ b/ios/scaffold.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		87C6A8F61B430EDD001876CE /* www in Resources */ = {isa = PBXBuildFile; fileRef = 87C6A8F51B430EDD001876CE /* www */; };
 		96C2AD861B62B6180032A784 /* app.js in Resources */ = {isa = PBXBuildFile; fileRef = 87C6A8F91B430FB7001876CE /* app.js */; };
 		B12FAF521C9751BC00F254BD /* app-www in Resources */ = {isa = PBXBuildFile; fileRef = B12FAF511C9751BC00F254BD /* app-www */; };
+		CBC6D60C1D19B7E900DC3785 /* PushClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBC6D60B1D19B7E900DC3785 /* PushClient.framework */; };
+		CBC6D60D1D19B7EF00DC3785 /* PushClient.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CBC6D60B1D19B7E900DC3785 /* PushClient.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,6 +43,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				CBC6D60D1D19B7EF00DC3785 /* PushClient.framework in Embed Frameworks */,
 				87132A211B6016FF00FC74A4 /* Astro.framework in Embed Frameworks */,
 				87132A231B6016FF00FC74A4 /* Cordova.framework in Embed Frameworks */,
 			);
@@ -68,6 +71,7 @@
 		87C6A8F71B430FA2001876CE /* app.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = app.js; path = ../../app/app.js; sourceTree = "<group>"; };
 		87C6A8F91B430FB7001876CE /* app.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = app.js; path = ../../app/build/app.js; sourceTree = "<group>"; };
 		B12FAF511C9751BC00F254BD /* app-www */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "app-www"; path = "../../app/app-www"; sourceTree = "<group>"; };
+		CBC6D60B1D19B7E900DC3785 /* PushClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PushClient.framework; path = "$(CONFIGURATION_BUILD_DIR)/PushClient.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +79,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CBC6D60C1D19B7E900DC3785 /* PushClient.framework in Frameworks */,
 				87132A201B6016FF00FC74A4 /* Astro.framework in Frameworks */,
 				87132A221B6016FF00FC74A4 /* Cordova.framework in Frameworks */,
 			);
@@ -101,6 +106,7 @@
 		87C6A87D1B43044D001876CE = {
 			isa = PBXGroup;
 			children = (
+				CBC6D60B1D19B7E900DC3785 /* PushClient.framework */,
 				87132A1E1B6016FF00FC74A4 /* Astro.framework */,
 				87132A1F1B6016FF00FC74A4 /* Cordova.framework */,
 				87C6A8D61B430E15001876CE /* Cordova */,

--- a/ios/scaffold.xcworkspace/contents.xcworkspacedata
+++ b/ios/scaffold.xcworkspace/contents.xcworkspacedata
@@ -10,6 +10,9 @@
       <FileRef
          location = "group:../node_modules/astro-sdk/ios/vendor/CordovaLib/CordovaLib.xcodeproj">
       </FileRef>
+      <FileRef
+         location = "group:../node_modules/astro-sdk/node_modules/mobify-push-ios-client/PushClient/PushClient.xcodeproj">
+      </FileRef>
    </Group>
    <FileRef
       location = "group:scaffold.xcodeproj">

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "0.13.0",
+    "astro-sdk": "mobify/astro.git#develop",
     "bluebird": "~2.9.24",
     "jquery": "^2.2.2",
     "navitron": "^1.0.0",


### PR DESCRIPTION
Include the PushClient iOS library

~~JIRA: **(link to JIRA ticket)**~~

## Changes
- Include the PushClient iOS library

## How to test-drive this PR
- If https://github.com/mobify/astro/pull/512 has not been merged into astro develop yet, update your `package.json` to point to astro.git/#ios-push-integration
- Build the app for iOS

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)

