### PR TITLE
iOS Cordova Charset

### DIFF
--- a/ios/Cordova/www/index.html
+++ b/ios/Cordova/www/index.html
@@ -29,6 +29,10 @@
                 * Enable inline JS: add 'unsafe-inline' to default-src
         -->
         <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: astro: https://ssl.gstatic.com https: 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *">
+
+        <!-- Allows emojis to be passed from worker to native iOS  -->
+        <meta charset="utf-8" />
+
         <title>Hello World</title>
     </head>
     <body>


### PR DESCRIPTION
Allow emojis to be passed over the worker/native bridge by specifying `utf-8` charset in the iOS Cordova `index.html` file.

JIRA: **N/A**
Linked PRs: **N/A**

## Changes
- Add `charset` `meta` tag with the `utf-8` value

## How to test-drive this PR
- A good test is to try and pass an emoji from `app.js` to the `AlertViewPlugin`. The emoji should appear.

## TODOS:
- [x] Change works in both ~~Android and~~ iOS.

~~- [ ] CHANGELOG.md has been updated.~~
~~- [ ] Run the generator to make sure it still functions correctly.~~

- [x] +1 from an engineer on the Astro team.

~~- [ ] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)~~

