### PR TITLE
HYB-695: Add iOS site association file

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ npm test
 - For Android, create a `HOCKEYAPP_TOKEN_ANDROID` key in Account Settings -> API Tokens. Copy & Paste the token into the `HOCKEYAPP_TOKEN_ANDROID` environment variable in CircleCI described in
  the above section CircleCI Setup
 
+# Universal Deep Linking iOS
+
+In order for the iOS app to support universal deep linking. The site which will be deeplinked from needs to host a `apple-app-site-association` file. The scaffold includes an example of this file at `ios/scaffold/apple-app-site-association`. Please see [Universal Linking Setup](https://developer.apple.com/library/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html) for more information.
+
 # Troubleshooting
 
 ![Screenshot of no available devices error](https://s3.amazonaws.com/uploads.hipchat.com/15359/58433/ACnytly3S1nHHkb/2015-08-12%2011.59.25%20am.png)

--- a/ios/scaffold/apple-app-site-association
+++ b/ios/scaffold/apple-app-site-association
@@ -3,7 +3,7 @@
         "apps": [],
         "details": [
             {
-                "appID": "DEV_TEAM_ID.com.mobify.astro",
+                "appID": "DEV_TEAM_ID.com.mobify.astro.scaffold",
                 "paths": [
                     "/",
                     "*"

--- a/ios/scaffold/apple-app-site-association
+++ b/ios/scaffold/apple-app-site-association
@@ -1,0 +1,21 @@
+{
+    "applinks": {
+        "apps": [],
+        "details": [
+            {
+                "appID": "DEV_TEAM_ID.com.mobify.astro",
+                "paths": [
+                    "/",
+                    "*"
+                ]
+            },
+            {
+                "appID": "RELEASE_TEAM_ID.com.releaseOrg.appName",
+                "paths": [
+                    "/",
+                    "*"
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Add the `apple-app-site-association` and update readme with instructions for setting up universal deep linking on customers site.

JIRA: https://mobify.atlassian.net/browse/HYB-695
Linked PRs: Deep linking mostly implemented in https://github.com/mobify/astro-scaffold/pull/106

## Changes
- Add a site association file

## How to test-drive this PR
- Inspection only

## TODOS:
- [ ] Change works in both Android and iOS.
- [ ] CHANGELOG.md has been updated.
- [ ] Run the generator to make sure it still functions correctly.
- [ ] +1 from an engineer on the Astro team.
- [ ] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)

