### PR TITLE
Linter and`package.json` updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ npm-debug.log
 
 android/.gradle
 android/local.properties
+android/.idea/vcs.xml
 android/.idea/workspace.xml
 android/.idea/libraries
 android/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## To be released
+- Updated `grunt-eslint` to v19.0.0
 - [Android] Updated to be compatible with Android Cordova v5.1.1
 - [iOS] Include pushclient module in iOS build
 - [iOS] Add support for universal deeplinking

--- a/app/tasks/config/eslint.js
+++ b/app/tasks/config/eslint.js
@@ -6,14 +6,14 @@ module.exports = function(grunt) {
             src: lint.targets,
             options: {
                 reset: true,
-                config: 'node_modules/mobify-code-style/javascript/.eslintrc'
+                configFile: 'node_modules/mobify-code-style/es5/mobify-es5.yml'
             }
         },
         prod: {
             src: lint.targets,
             options: {
                 reset: true,
-                config: 'node_modules/mobify-code-style/javascript/.eslintrc'
+                configFile: 'node_modules/mobify-code-style/es5/mobify-es5.yml'
             }
         }
     };

--- a/app/tests/system/assertions/global.js
+++ b/app/tests/system/assertions/global.js
@@ -29,11 +29,11 @@ GlobalAssertions.prototype.assertPortrait = function() {
                 .execute(function() {
                     return window.orientation;
                 }, function(result) {
-                        var rotation = result.value;
-                        self.browser.log('Window orientation should be portrait.');
-                        this.assert.equal(rotation, orientations.portrait);
-                    }
-                );
+                    var rotation = result.value;
+                    self.browser.log('Window orientation should be portrait.');
+                    this.assert.equal(rotation, orientations.portrait);
+                }
+            );
         });
     return this;
 };
@@ -54,12 +54,12 @@ GlobalAssertions.prototype.assertLandscape = function() {
                 .execute(function() {
                     return window.orientation;
                 }, function(result) {
-                        var rotation = result.value;
-                        self.browser.log('Window orientation should be (counter)clockwise.');
-                        this.assert.notEqual(rotation, orientations.portrait);
-                        this.assert.notEqual(rotation, orientations.upsideDown);
-                    }
-                );
+                    var rotation = result.value;
+                    self.browser.log('Window orientation should be (counter)clockwise.');
+                    this.assert.notEqual(rotation, orientations.portrait);
+                    this.assert.notEqual(rotation, orientations.upsideDown);
+                }
+            );
         });
     return this;
 };

--- a/app/tests/system/pages/web/homepage.js
+++ b/app/tests/system/pages/web/homepage.js
@@ -1,22 +1,22 @@
 module.exports = {
-  setUp: function(browser) {
-      browser
-      .pause(3000)
-      .contexts(function(result) {
-          browser.log(result.value);
-      });
-  },
+    setUp: function(browser) {
+        browser
+        .pause(3000)
+        .contexts(function(result) {
+            browser.log(result.value);
+        });
+    },
 
-  'Verify webview URL': function(browser) {
-      browser
-      .contexts(function(result) {
-          browser
-          .setContext(result.value[result.value.length - 1])
-          .url(function(url) {
-              browser.log(url.value);
-          })
-          .assert.urlContains('https://webpush-you-host.mobifydemo.io/about/');
-      })
-      .end();
-  }
+    'Verify webview URL': function(browser) {
+        browser
+        .contexts(function(result) {
+            browser
+            .setContext(result.value[result.value.length - 1])
+            .url(function(url) {
+                browser.log(url.value);
+            })
+            .assert.urlContains('https://webpush-you-host.mobifydemo.io/about/');
+        })
+        .end();
+    }
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^1.1.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-eslint": "^13.0.0",
+    "grunt-eslint": "^19.0.0",
     "mobify-code-style": "^2.2.1",
     "nightwatch": "0.8.18",
     "nightwatch-commands": "1.5.0"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^19.0.0",
     "mobify-code-style": "^2.2.1",
-    "nightwatch": "0.8.18",
-    "nightwatch-commands": "1.5.0"
+    "nightwatch": "0.9.6",
+    "nightwatch-commands": "1.7.0"
   },
   "scripts": {
     "test": "./scripts/ios-appium.sh"

--- a/scripts/ios-appium.sh
+++ b/scripts/ios-appium.sh
@@ -5,7 +5,7 @@ set -o pipefail
 MYPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT=$MYPATH/..
 export IOS_DEVICE_NAME="iPhone 6"
-export IOS_VERSION="9.2"
+export IOS_VERSION="9.3"
 
 # Kill background processes when this script exits.
 trap 'kill $(jobs -p)' EXIT


### PR DESCRIPTION
The `package.json` dependencies are getting a bit stale. This PR updates them and fixes the linter config to point to the latest `mobify-code-style` rules.

**Note**: It seems like the Selenium tests are failing and probably have been for a while. I'm not addressing them in this PR but we should in a future PR... soon... 

JIRA: N/A
Linked PRs: N/A

## Changes
- Upgrade to `grunt-eslint` v 19.0.0
- Fix eslint config for new version of eslint
- Fix new linter errors in `js` tests

## How to test-drive this PR
- Run `npm i`
- Run `app/build-js.sh`
- Run the app on iOS and Android

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)

