### PR TITLE
Make build-js.sh smarter about finding npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## To be released
+- `build-js.sh` is much smarter and looks for npm in `.nvm` now!
 - Updated `grunt-eslint` to v19.0.0
 - [Android] Updated to be compatible with Android Cordova v5.1.1
 - [iOS] Include pushclient module in iOS build

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -5,19 +5,35 @@ set -e
 MYPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT=$MYPATH/..
 
+function findNode() {
+    return $(which npm 1>/dev/null 2>&1)
+}
+
 pushd "$MYPATH"
 
 # Force supporting Homebrew installations of npm.
 export PATH=$PATH:/usr/local/bin
 
-# Source additional configuration from `user-env.sh` in Astro's root.
-if [ -f user-env.sh ]; then
-    echo "Found user-env.sh"
-    source user-env.sh
+if ! findNode; then
+    echo "Cannot find 'npm'. Trying via nvm..."
+    # Find node with nvm
+    if [ -d "$HOME/.nvm" ]; then
+        echo " ↳  Found $HOME/.nvm  Sourcing and retrying build..."
+        . "$HOME/.nvm/nvm.sh"
+    fi
 fi
 
-if ! which npm 1>/dev/null 2>&1; then
-    echo "Cannot find 'npm'.  Please ensure 'npm' is in your PATH."
+if ! findNode; then
+    echo "Cannot find 'npm'. Trying via user-env.sh..."
+    # Source additional configuration from `user-env.sh` in Astro's root.
+    if [ -f user-env.sh ]; then
+        echo " ↳  Found user-env.sh  Sourcing and retrying build..."
+        source user-env.sh
+    fi
+fi
+
+if ! findNode; then
+    echo "Cannot find 'npm'. Aborting. Add your npm path to \`user-env.sh\` and retry."
     exit 1
 fi
 

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -47,7 +47,7 @@ cp $ROOT/node_modules/jquery/dist/jquery.min.js $MYPATH/app-www/js
 
 # Build astro-client.js
 pushd $ROOT/node_modules/astro-sdk
-npm install
+npm install --no-progress --no-spin
 $MYPATH/node_modules/grunt-cli/bin/grunt build_astro_client
 cp js/build/astro-client.js $MYPATH/app-www/js
 popd

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -4,10 +4,17 @@ set -e
 
 MYPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT=$MYPATH/..
+EXTRA_NPM_ARGS=""
+EXTRA_GRUNT_ARGS=""
 
 function findNode() {
     return $(which npm 1>/dev/null 2>&1)
 }
+
+if [ "$1" == "--no-color" ]; then
+    EXTRA_NPM_ARGS="--no-color $EXTRA_NPM_ARGS"
+    EXTRA_GRUNT_ARGS="--no-color $EXTRA_GRUNT_ARGS"
+fi
 
 pushd "$MYPATH"
 
@@ -47,12 +54,12 @@ cp $ROOT/node_modules/jquery/dist/jquery.min.js $MYPATH/app-www/js
 
 # Build astro-client.js
 pushd $ROOT/node_modules/astro-sdk
-npm install --no-progress --no-spin
-$MYPATH/node_modules/grunt-cli/bin/grunt build_astro_client
+npm install --no-progress --no-spin $EXTRA_NPM_ARGS
+$MYPATH/node_modules/grunt-cli/bin/grunt $EXTRA_GRUNT_ARGS build_astro_client
 cp js/build/astro-client.js $MYPATH/app-www/js
 popd
 
 # Build app.js.
 pushd $MYPATH
-$MYPATH/node_modules/grunt-cli/bin/grunt build
+$MYPATH/node_modules/grunt-cli/bin/grunt $EXTRA_GRUNT_ARGS build
 popd

--- a/ios/scaffold.xcodeproj/project.pbxproj
+++ b/ios/scaffold.xcodeproj/project.pbxproj
@@ -316,7 +316,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "../app/build-js.sh";
+			shellScript = "../app/build-js.sh --no-color";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Make `build-js.sh` smarter about finding `npm` when it's not in the path.

JIRA: N/A
Linked PRs: N/A

## Changes
- The build script now checks if `~/.nvm` exists and if it does, assumes that that's where it can find npm.

## How to test-drive this PR
- Start a new shell
- Remove nvm from the `$PATH`
- Run `build-js.sh` and make sure it prints out that it found `.nvm` and is sourcing it... then the build should succeed.

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)

