### PR TITLE
[Android] Launch Screens

### DIFF
--- a/android/scaffold/src/main/AndroidManifest.xml
+++ b/android/scaffold/src/main/AndroidManifest.xml
@@ -8,14 +8,21 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name">
         <activity
+            android:name=".LaunchActivity"
+            android:label="@string/app_name"
+            android:theme="@style/LaunchTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".MainActivity"
             android:screenOrientation="portrait"
             android:label="@string/app_name"
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/android/scaffold/src/main/java/com/mobify/astro/scaffold/LaunchActivity.java
+++ b/android/scaffold/src/main/java/com/mobify/astro/scaffold/LaunchActivity.java
@@ -1,0 +1,15 @@
+package com.mobify.astro.scaffold;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+public class LaunchActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = new Intent(this, MainActivity.class);
+        startActivity(intent);
+        finish();
+    }
+}

--- a/android/scaffold/src/main/res/drawable/launch_screen.xml
+++ b/android/scaffold/src/main/res/drawable/launch_screen.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/white"/>
+    <item>
+        <bitmap android:gravity="center" android:src="@mipmap/ic_launcher"/>
+    </item>
+</layer-list>

--- a/android/scaffold/src/main/res/values/colors.xml
+++ b/android/scaffold/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="white">#FFFFFF</color>
+</resources>

--- a/android/scaffold/src/main/res/values/styles.xml
+++ b/android/scaffold/src/main/res/values/styles.xml
@@ -5,4 +5,9 @@
         <!-- Customize your theme here. -->
     </style>
 
+    <!-- Launch screen theme. -->
+    <style name="LaunchTheme" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowBackground">@drawable/launch_screen</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
We're planning to give the splashScreenPlugin the boot, and thinking of implementing these launch images natively. This PR does just that -- pulling in a similar implementation of the native splash screen that was done for eXtra.

JIRA: 
1. [HYB-452 - Splash screen on Android has a very small image #bug](https://mobify.atlassian.net/browse/HYB-452)
2. [HYB-642 - Revisit the way we handle splash screens](https://mobify.atlassian.net/browse/HYB-642)
3. [HYB-860 - As a Scaffold user, I want my astro app to start up with a splash screen that can be customized per app. The splash screen should show on app launch and hide to reveal a fully loaded UI.](https://mobify.atlassian.net/browse/HYB-860)

Linked PRs: **[extra-mobile#283](https://github.com/mobify/extra-mobile/pull/283)**

## Changes
- Added a native Launch Screen for Android (iOS already has a stub one)

## How to test-drive this PR
- Launch the Android app, see the Launch Screen 💥 

## TODOS:
- [ ] Change works in both Android and iOS.
- [ ] CHANGELOG.md has been updated.
- [ ] Run the generator to make sure it still functions correctly.
- [ ] +1 from an engineer on the Astro team.
- [ ] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)

