### PR TITLE
Move www dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,11 +14,7 @@ android/.idea/libraries
 android/build
 android/gradle.properties
 
-/app/app-www/js/*
-!/app/app-www/js/left-drawer.js
-!/app/app-www/js/config.js
-!/app/app-www/js/error.js
-!/app/app-www/js/global.js
+/app/app-www/js/build
 
 ### Xcode ###
 build/

--- a/app/app-www/html/error.html
+++ b/app/app-www/html/error.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <script src="../js/astro-client.js"></script>
+        <script src="../js/build/astro-client.js"></script>
         <link rel="stylesheet" href="../css/shared.css">
         <link rel="stylesheet" href="../css/error__style.css">
     </head>
@@ -17,6 +17,6 @@
             </div>
         </section>
         </div>
-        <script data-main="../js/error.js" src="../js/require.js"></script>
+        <script data-main="../js/error.js" src="../js/build/require.js"></script>
     </body>
 </html>

--- a/app/app-www/html/left-drawer.html
+++ b/app/app-www/html/left-drawer.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../css/navitron/navitron-theme.css">
     <link rel="stylesheet" href="../css/navitron/navitron-custom.css">
 
-    <script src="../js/astro-client.js"></script>
+    <script src="../js/build/astro-client.js"></script>
 </head>
 <body>
     <nav id="leftMenuNavitron" hidden>
@@ -29,7 +29,7 @@
         </ul>
     </nav>
 
-    <script data-main="../js/left-drawer.js" src="../js/require.js"></script>
+    <script data-main="../js/left-drawer.js" src="../js/build/require.js"></script>
 
 </body>
 </html>

--- a/app/app-www/html/search-bar.html
+++ b/app/app-www/html/search-bar.html
@@ -2,8 +2,8 @@
 <html>
     <head>
         <meta name="viewport" content="initial-scale=1, user-scalable=no">
-        <script src="../js/astro-client.js"></script>
-        <script src="../js/jquery.min.js"></script>
+        <script src="../js/build/astro-client.js"></script>
+        <script src="../js/build/jquery.min.js"></script>
         <link rel="stylesheet" type="text/css" href="../css/search-bar.css">
     </head>
     <body>

--- a/app/app-www/html/welcome.html
+++ b/app/app-www/html/welcome.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-        <script src="../js/astro-client.js"></script>
+        <script src="../js/build/astro-client.js"></script>
         <link rel="stylesheet" href="../css/welcome__style.css">
     </head>
     <body>

--- a/app/app-www/js/config.js
+++ b/app/app-www/js/config.js
@@ -1,11 +1,11 @@
 require.config({
-    baseUrl: '../js',
+    baseUrl: '../js/build',
     deps: ['global'],
     paths: {
-        '$': 'build/jquery.min',
-        'velocity': 'build/velocity.min',
-        'navitron': 'build/navitron.min',
-        'plugin': 'build/plugin.min'
+        '$': 'jquery.min',
+        'velocity': 'velocity.min',
+        'navitron': 'navitron.min',
+        'plugin': 'plugin.min'
     },
     'shim': {
         '$': {

--- a/app/app-www/js/config.js
+++ b/app/app-www/js/config.js
@@ -2,10 +2,10 @@ require.config({
     baseUrl: '../js',
     deps: ['global'],
     paths: {
-        '$': 'jquery.min',
-        'velocity': 'velocity.min',
-        'navitron': 'navitron.min',
-        'plugin': 'plugin.min'
+        '$': 'build/jquery.min',
+        'velocity': 'build/velocity.min',
+        'navitron': 'build/navitron.min',
+        'plugin': 'build/plugin.min'
     },
     'shim': {
         '$': {

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -44,6 +44,10 @@ if ! findNode; then
     exit 1
 fi
 
+if [ ! -d $MYPATH/app-www/js/build ] ; then
+    mkdir $MYPATH/app-www/js/build
+fi
+
 # Add navitron & its dependencies to the app bundle
 cp $MYPATH/node_modules/grunt-requirejs/node_modules/requirejs/require.js $MYPATH/app-www/js/build
 cp $MYPATH/node_modules/navitron/node_modules/plugin/dist/plugin*.js $MYPATH/app-www/js/build

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -45,18 +45,18 @@ if ! findNode; then
 fi
 
 # Add navitron & its dependencies to the app bundle
-cp $MYPATH/node_modules/grunt-requirejs/node_modules/requirejs/require.js $MYPATH/app-www/js
-cp $MYPATH/node_modules/navitron/node_modules/plugin/dist/plugin*.js $MYPATH/app-www/js
-cp $MYPATH/node_modules/navitron/node_modules/velocity-animate/velocity.* $MYPATH/app-www/js
-cp $MYPATH/node_modules/navitron/dist/navitron*.js $MYPATH/app-www/js
+cp $MYPATH/node_modules/grunt-requirejs/node_modules/requirejs/require.js $MYPATH/app-www/js/build
+cp $MYPATH/node_modules/navitron/node_modules/plugin/dist/plugin*.js $MYPATH/app-www/js/build
+cp $MYPATH/node_modules/navitron/node_modules/velocity-animate/velocity.* $MYPATH/app-www/js/build
+cp $MYPATH/node_modules/navitron/dist/navitron*.js $MYPATH/app-www/js/build
 
-cp $ROOT/node_modules/jquery/dist/jquery.min.js $MYPATH/app-www/js
+cp $ROOT/node_modules/jquery/dist/jquery.min.js $MYPATH/app-www/js/build
 
 # Build astro-client.js
 pushd $ROOT/node_modules/astro-sdk
 npm install --no-progress --no-spin $EXTRA_NPM_ARGS
 $MYPATH/node_modules/grunt-cli/bin/grunt $EXTRA_GRUNT_ARGS build_astro_client
-cp js/build/astro-client.js $MYPATH/app-www/js
+cp js/build/astro-client.js $MYPATH/app-www/js/build
 popd
 
 # Build app.js.


### PR DESCRIPTION
Last PR?! 🎉 💥 

JIRA: **None**
Linked PRs: **None**

## Changes
- Move third party dependencies into a `/build` folder, this makes it easier to manage our gitignore :)

## How to test-drive this PR
- Make sure everything still works

## TODOS:
- [X] Change works in both Android and iOS.
- ~~[ ] CHANGELOG.md has been updated.~~
- [ ] Run the generator to make sure it still functions correctly.
- [ ] +1 from an engineer on the Astro team.
- [X] Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)

