### PR TITLE
Set iOS project to 'iPhone' instead of 'Universal'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add Requirements to README, and "engines" field to package.json
 - Add Segmented Plugin
 - Replace WebView search bar with Search Bar Plugin
+- Set iOS projects to 'iPhone' instead of 'Universal' by default
 
 ## v0.15.0
 - [iOS] Remove update bundle version build phase

--- a/ios/scaffold.xcodeproj/project.pbxproj
+++ b/ios/scaffold.xcodeproj/project.pbxproj
@@ -406,6 +406,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mobify.astro.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = UAT;
 		};
@@ -525,6 +526,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mobify.astro.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -542,6 +544,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mobify.astro.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/ios/scaffold/Info.plist
+++ b/ios/scaffold/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ios/scaffold/Info.plist
+++ b/ios/scaffold/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Set iOS project to 'iPhone' instead of 'Universal' - the majority of our builds do not include iPad support

~~JIRA: **(link to JIRA ticket)**~~

## Changes
- Set iOS project to 'iPhone' instead of 'Universal'

## How to test-drive this PR
- Build and run

## TODOS:
~~- [ ] Change works in both Android and iOS.~~

- [x] CHANGELOG.md has been updated.
- [ ] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.

~~- [ ] Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)~~
