### PR TITLE
Fix errorController when displayed from cart and refactor hardware back button handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add Segmented Plugin
 - Replace WebView search bar with Search Bar Plugin
 - Set iOS projects to 'iPhone' instead of 'Universal' by default
+- Fix up error controller and error modal text
+- [Android] setup hardware back button and fix for both tab layout and left-nav layout
 
 ## v0.15.0
 - [iOS] Remove update bundle version build phase

--- a/app/app-controllers/cart/cartModalController.js
+++ b/app/app-controllers/cart/cartModalController.js
@@ -17,10 +17,11 @@ function(
 ) {
 /* eslint-enable */
 
-    var CartModalController = function(modalView, cartController) {
+    var CartModalController = function(modalView, cartController, errorController) {
         this.isShowing = false;
         this.viewPlugin = modalView;
         this.cartController = cartController;
+        this.errorController = errorController;
 
         // Privileged methods
         this._reload = function() {
@@ -40,7 +41,7 @@ function(
         function(cartController, modalView, errorController) {
             modalView.setContentView(cartController.viewPlugin);
 
-            var cartModalController = new CartModalController(modalView, cartController);
+            var cartModalController = new CartModalController(modalView, cartController, errorController);
             cartController.registerCloseEventHandler(function() {
                 cartModalController.hide();
             });
@@ -94,6 +95,10 @@ function(
     };
 
     CartModalController.prototype.hide = function() {
+        if (this.errorController.isShowing) {
+            this.errorController.hide();
+        }
+
         // We load a blank page upon hide to prevent displaying
         // previously loaded content when we open the cart
         AppEvents.trigger(AppEvents.names.cartHidden);

--- a/app/app-controllers/cart/cartModalController.js
+++ b/app/app-controllers/cart/cartModalController.js
@@ -17,11 +17,10 @@ function(
 ) {
 /* eslint-enable */
 
-    var CartModalController = function(modalView, cartController, errorController) {
+    var CartModalController = function(modalView, cartController) {
         this.isShowing = false;
         this.viewPlugin = modalView;
         this.cartController = cartController;
-        this.errorController = errorController;
 
         // Privileged methods
         this._reload = function() {
@@ -41,7 +40,7 @@ function(
         function(cartController, modalView, errorController) {
             modalView.setContentView(cartController.viewPlugin);
 
-            var cartModalController = new CartModalController(modalView, cartController, errorController);
+            var cartModalController = new CartModalController(modalView, cartController);
             cartController.registerCloseEventHandler(function() {
                 cartModalController.hide();
             });
@@ -95,10 +94,6 @@ function(
     };
 
     CartModalController.prototype.hide = function() {
-        if (this.errorController.isShowing) {
-            this.errorController.hide();
-        }
-
         // We load a blank page upon hide to prevent displaying
         // previously loaded content when we open the cart
         AppEvents.trigger(AppEvents.names.cartHidden);

--- a/app/app-controllers/cart/cartModalController.js
+++ b/app/app-controllers/cart/cartModalController.js
@@ -74,7 +74,8 @@ function(
                 navigator: cartController.webView,
                 backHandler: backHandler,
                 retryHandler: retryHandler,
-                isActiveItem: cartModalController.isActiveItem.bind(cartModalController)
+                isActiveItem: cartModalController.isActiveItem.bind(cartModalController),
+                canGoBack: canGoBack
             });
 
             return cartModalController;

--- a/app/app-controllers/error-screen/errorController.js
+++ b/app/app-controllers/error-screen/errorController.js
@@ -1,7 +1,6 @@
 define([
     'astro-full',
     'bluebird',
-    'application',
     'config/errorConfig',
     'config/baseConfig',
     'plugins/webViewPlugin',
@@ -10,7 +9,6 @@ define([
 ], function(
     Astro,
     Promise,
-    Application,
     ErrorConfig,
     BaseConfig,
     WebViewPlugin,

--- a/app/app-controllers/tabBarController.js
+++ b/app/app-controllers/tabBarController.js
@@ -139,6 +139,13 @@ function(
         return this.getActiveNavigationView().navigate(url);
     };
 
+    TabBarController.prototype.backActiveItem = function() {
+        if (this.canGoBack()) {
+            var activeTab = this.getActiveNavigationView()
+            activeTab.back();
+        }
+    };
+
     TabBarController.prototype.canGoBack = function() {
         var activeTab = this.getActiveNavigationView();
         return activeTab.canGoBack();

--- a/app/app-www/js/config.js
+++ b/app/app-www/js/config.js
@@ -1,6 +1,6 @@
 require.config({
     baseUrl: '../js/build',
-    deps: ['global'],
+    deps: ['../global'],
     paths: {
         '$': 'jquery.min',
         'velocity': 'velocity.min',

--- a/app/app.js
+++ b/app/app.js
@@ -54,7 +54,6 @@ window.run = function() {
         });
 
         // Android hardware back
-        // TODO jason - test with tab layout
         var setupHardwareBackButton = function(alternativeBackFunction) {
             Application.on('backButtonPressed', function() {
                 Promise.join(

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "mobify/astro.git#back-pressed-for-modal",
+    "astro-sdk": "mobify/astro.git#develop",
     "bluebird": "~2.9.24",
     "jquery": "^2.2.2",
     "navitron": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "mobify/astro.git#develop",
+    "astro-sdk": "mobify/astro.git#back-pressed-for-modal",
     "bluebird": "~2.9.24",
     "jquery": "^2.2.2",
     "navitron": "^1.0.0",


### PR DESCRIPTION
JIRA: **none**
Linked PRs: **https://github.com/mobify/astro/pull/621**

## Changes
- Supply `canGoBack` function to `errorController` within the cart modal.
- Fix hardware back button functionality for modals (changes as a result of linked PR)
- Wire up hardware back button for tab layout
- fix: error dialog text -- wasn't getting filled in before due to dependency issue
- fix: error dialog back button should not show if app cannot go back

## How to test-drive this PR
- Run scaffold
- Open cart
- Turn off internet on device
- Click a link in the cart (one of the items in the right drawer within the cart works)
- Ensure you get an error modal (previously there was none)
- Do this in multiple different scenarios and make sure back button + hardware back button work correctly (i.e. modals, tab vs. side-nav layout)

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [ ] ~~Run the generator to make sure it still functions correctly.~~
- [x] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)

