### PR TITLE
Pull in build improvements resulting from eXtra Xcode 8 upgrade

### DIFF
--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -42,11 +42,6 @@ if ! findNode; then
     exit 1
 fi
 
-echo "Creating build directory"
-if [ ! -d $MYPATH/app-www/js/build ] ; then
-    mkdir $MYPATH/app-www/js/build
-fi
-
 echo "Building app.js"
 pushd $MYPATH
     $MYPATH/node_modules/.bin/grunt $EXTRA_GRUNT_ARGS build

--- a/app/build-js.sh
+++ b/app/build-js.sh
@@ -16,9 +16,6 @@ if [ "$1" == "--no-color" ]; then
     EXTRA_GRUNT_ARGS="--no-color $EXTRA_GRUNT_ARGS"
 fi
 
-# Force supporting Homebrew installations of npm.
-export PATH=$PATH:/usr/local/bin
-
 if ! findNode; then
     echo "Cannot find 'npm'. Trying via nvm..."
     # Find node with nvm
@@ -36,6 +33,9 @@ if ! findNode; then
         source user-env.sh
     fi
 fi
+
+# Force supporting Homebrew installations of npm.
+export PATH=$PATH:/usr/local/bin
 
 if ! findNode; then
     echo "Cannot find 'npm'. Aborting. Add your npm path to \`user-env.sh\` and retry."

--- a/ios/Cordova/www/index.html
+++ b/ios/Cordova/www/index.html
@@ -33,7 +33,7 @@
         <!-- Allows emojis to be passed from worker to native iOS  -->
         <meta charset="utf-8" />
 
-        <title>Hello World</title>
+        <title>Astro Worker</title>
     </head>
     <body>
         <script type="text/javascript" src="cordova.js"></script>

--- a/scripts/build-dependencies.sh
+++ b/scripts/build-dependencies.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-function findNode() {
-    return $(which npm 1>/dev/null 2>&1)
-}
-
 while [[ $# -gt 0 ]]
 do
 key="$1"

--- a/scripts/build-dependencies.sh
+++ b/scripts/build-dependencies.sh
@@ -54,6 +54,7 @@ cp $MYPATH/node_modules/navitron/node_modules/plugin/dist/plugin*.js $MYPATH/app
 cp $MYPATH/node_modules/navitron/node_modules/velocity-animate/velocity.* $MYPATH/app-www/js/build
 cp $MYPATH/node_modules/navitron/dist/navitron*.js $MYPATH/app-www/js/build
 cp $MYPATH/node_modules/jquery/dist/jquery.min.js $MYPATH/app-www/js/build
+cp $MYPATH/node_modules/bluebird/js/browser/bluebird*.js $MYPATH/app-www/js/build
 
 pushd $MYPATH/node_modules/astro-sdk
     echo "Installing dependencies for astro-sdk"


### PR DESCRIPTION
JIRA: **none**
Linked PRs: **none**

## Changes
- copy `bluebird` over into `app-www` in `build-dependencies.sh`
- remove old directory check/create code in `build-js.sh` since it has been moved to `build-dependencies.sh` and building `app.js` shouldn't require that folder to exist
- Set the title in the cordova `index.html` to "Astro Worker" for easier debugging

![image](https://cloud.githubusercontent.com/assets/1031170/19704639/33a824d8-9abd-11e6-99de-aca5e290e62e.png)


## How to test-drive this PR
- blow away your `app/app-www/js/build` directory
- `npm run deps`
- run scaffold app
- attach the safari debugger

## TODOS:
- [x] Change works in both Android and iOS.
- [ ] ~~CHANGELOG.md has been updated.~~
- [ ] ~~Run the generator to make sure it still functions correctly.~~
- [x] +1 from an engineer on the Astro team.
- [ ] ~~Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)~~

