### PR TITLE
Remove runloop spin, Astro fixed this finally!

### DIFF
--- a/ios/scaffold/AppDelegate.swift
+++ b/ios/scaffold/AppDelegate.swift
@@ -34,13 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         window?.rootViewController = astroViewController
         window?.makeKeyAndVisible()
-        
-        // This is as sketchy as it appears.  We want to let the main thread run loop
-        // run so that the AstroViewController can spin up and get app.js executing.
-        // This allows any splash screen presented to be displayed before the Launch Image
-        // is dismissed (at the end of didFinishLaunchingWithOptions).
-        RunLoop.main.run(until: Date().addingTimeInterval(1.0))
-        
+
         // Return false to avoid calling openURL. The deeplink url has already been handled in Astro.
         return false
     }


### PR DESCRIPTION
Fixes a bug where the headerbar and navigationplugin become "unsynced" on launch. See linked Astro PR.

JIRA: https://mobify.atlassian.net/browse/HYB-936
Linked PRs: https://github.com/mobify/astro/pull/663

## Changes
- Remove "run loop" spin in AppDelegate.

## How to test-drive this PR
- Run the app
- Navigate forward and back
- Verify that the head bar remains in sync at all times.

## TODOS:
~~- [ ] Change works in both Android and iOS.~~
~~- [ ] CHANGELOG.md has been updated.~~

- [x] Run the generator to make sure it still functions correctly.
- [ ] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)

