### PR TITLE
[HYB-968]: Multiple build configurations to support builds with preview enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.17.6
+- Add multiple build configurations to support enabling/disabling Mobify Preview
+
 ## v0.17.3
 - Manually dismiss launch image
 

--- a/android/scaffold/build.gradle
+++ b/android/scaffold/build.gradle
@@ -18,6 +18,19 @@ android {
         }
         debug {}
     }
+    productFlavors {
+        previewEnabled {
+            applicationId "com.mobify.astro.scaffold.preview"
+        }
+        previewDisabled {}
+    }
+}
+
+configurations {
+    previewEnabledDebugCompile
+    previewDisabledDebugCompile
+    previewEnabledReleaseCompile
+    previewDisabledReleaseCompile
 }
 
 task buildJS(type:Exec) {
@@ -29,6 +42,9 @@ preBuild.dependsOn buildJS
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.3.0'
-    releaseCompile project(path: ':astro', configuration: 'release')
-    debugCompile project(path: ':astro', configuration: 'debug')
+
+    previewEnabledDebugCompile project(path: ':astro', configuration: 'previewEnabledDebug')
+    previewDisabledDebugCompile project(path: ':astro', configuration: 'previewDisabledDebug')
+    previewEnabledReleaseCompile project(path: ':astro', configuration: 'previewEnabledRelease')
+    previewDisabledReleaseCompile project(path: ':astro', configuration: 'previewDisabledRelease')
 }

--- a/app/app-config/baseConfig.js
+++ b/app/app-config/baseConfig.js
@@ -7,7 +7,6 @@ define([], function() {
     // the generator as well! 🙏🏻
     // start: lines altered by generator
     var useTabLayout = false;
-    var previewEnabled = false;
     var previewBundle = '<preview_bundle>';
     // end: lines altered by generator
 
@@ -24,7 +23,6 @@ define([], function() {
         colors: colors,
         loaderColor: loaderColor,
         previewBundle: previewBundle,
-        previewEnabled: previewEnabled,
         useTabLayout: useTabLayout
     };
 });

--- a/app/app.js
+++ b/app/app.js
@@ -1,3 +1,4 @@
+/*global AstroNative*/
 window.AstroMessages = []; // For debugging messages
 
 window.run = function() {
@@ -162,21 +163,27 @@ window.run = function() {
                 });
         };
 
-        PreviewController.init().then(function(previewController) {
-            Application.on('previewToggled', function() {
-                previewController.presentPreviewAlert();
-            });
+        var initalizeAppWithAstroPreview = function() {
+            PreviewController.init().then(function(previewController) {
+                Application.on('previewToggled', function() {
+                    previewController.presentPreviewAlert();
+                });
 
-            previewController.isPreviewEnabled().then(function(enabled) {
-                // Configure the previewEnabled flag located in baseConfig.js
-                // to enable/disable app preview
-                if (enabled && BaseConfig.previewEnabled) {
+                return previewController.isPreviewEnabled();
+            }).then(function(previewEnabled) {
+                if (previewEnabled) {
                     runAppPreview();
                 } else {
                     runApp();
                 }
             });
-        });
+        };
+
+        if (AstroNative.Configuration.ASTRO_PREVIEW) {
+            initalizeAppWithAstroPreview();
+        } else {
+            runApp();
+        }
     }, undefined, true);
 };
 // Comment out next line for JS debugging

--- a/ios/scaffold.xcodeproj/project.pbxproj
+++ b/ios/scaffold.xcodeproj/project.pbxproj
@@ -405,7 +405,7 @@
 				INFOPLIST_FILE = scaffold/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_SWIFT_FLAGS = "-D RELEASE -D ASTRO_PREVIEW";
+				OTHER_SWIFT_FLAGS = "-D RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mobify.astro.$(PRODUCT_NAME:rfc1034identifier)-preview";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 2.3;

--- a/ios/scaffold.xcodeproj/project.pbxproj
+++ b/ios/scaffold.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		01BDD1941B87ABA500E4CB88 /* UAT */ = {
+		6EFD09EF1DEE499800BDD01E /* PreviewEnabledRelease */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -384,16 +384,18 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_SWIFT_FLAGS = "-D UAT";
+				OTHER_SWIFT_FLAGS = "-D RELEASE";
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
-			name = UAT;
+			name = PreviewEnabledRelease;
 		};
-		01BDD1951B87ABA500E4CB88 /* UAT */ = {
+		6EFD09F01DEE499800BDD01E /* PreviewEnabledRelease */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = scaffold/scaffold.entitlements;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -403,14 +405,15 @@
 				INFOPLIST_FILE = scaffold/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.mobify.astro.$(PRODUCT_NAME:rfc1034identifier)";
+				OTHER_SWIFT_FLAGS = "-D RELEASE -D ASTRO_PREVIEW";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mobify.astro.$(PRODUCT_NAME:rfc1034identifier)-preview";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
-			name = UAT;
+			name = PreviewEnabledRelease;
 		};
-		01BDD1961B87ABA500E4CB88 /* UAT */ = {
+		6EFD09F11DEE499800BDD01E /* PreviewEnabledRelease */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -425,7 +428,7 @@
 				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/scaffold.app/scaffold";
 			};
-			name = UAT;
+			name = PreviewEnabledRelease;
 		};
 		87C6A8A31B43044D001876CE /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -604,7 +607,7 @@
 			buildConfigurations = (
 				87C6A8A31B43044D001876CE /* Debug */,
 				87C6A8A41B43044D001876CE /* Release */,
-				01BDD1941B87ABA500E4CB88 /* UAT */,
+				6EFD09EF1DEE499800BDD01E /* PreviewEnabledRelease */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -614,7 +617,7 @@
 			buildConfigurations = (
 				87C6A8A61B43044D001876CE /* Debug */,
 				87C6A8A71B43044D001876CE /* Release */,
-				01BDD1951B87ABA500E4CB88 /* UAT */,
+				6EFD09F01DEE499800BDD01E /* PreviewEnabledRelease */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -624,7 +627,7 @@
 			buildConfigurations = (
 				87C6A8A91B43044D001876CE /* Debug */,
 				87C6A8AA1B43044D001876CE /* Release */,
-				01BDD1961B87ABA500E4CB88 /* UAT */,
+				6EFD09F11DEE499800BDD01E /* PreviewEnabledRelease */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "mobify/astro.git#release-v0.17.6",
+    "astro-sdk": "~0.17.0",
     "bluebird": "~2.9.24",
     "jquery": "^2.2.2",
     "navitron": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "~0.17.3",
+    "astro-sdk": "mobify/astro.git#preview-build-variants",
     "bluebird": "~2.9.24",
     "jquery": "^2.2.2",
     "navitron": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "mobify/astro.git#preview-build-variants",
+    "astro-sdk": "mobify/astro.git#release-v0.17.6",
     "bluebird": "~2.9.24",
     "jquery": "^2.2.2",
     "navitron": "^1.0.0",


### PR DESCRIPTION
Astro now supports multiple build configurations. Scaffold will support the same build configurations. 

JIRA: https://mobify.atlassian.net/browse/HYB-968
Linked PRs: https://github.com/mobify/astro/pull/714
https://github.com/mobify/generator-astro/pull/42

## Changes
- Update with new build configurations for ios and android
- `App.js` checks the `ASTRO_PREVIEW` flag before it decides whether it needs to create and query the `PreviewController`

## How to test-drive this PR
- Run different configurations of app (ios and android)
- When preview is disabled ensure that shake doesn't do anything
- When preview is enabled ensure that shaking causes the preview alert dialog to come up
- Check restarting the app shows the preview modal when preview is enabled in the alert dialog

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)
- [x] Update to released version of astro