### PR TITLE
Broken android build with 4 variants and webpack changes

### DIFF
--- a/android/scaffold/build.gradle
+++ b/android/scaffold/build.gradle
@@ -45,7 +45,7 @@ task buildJSRelease(type:Exec) {
 
 afterEvaluate {
     android.applicationVariants.all { variant ->
-        variant.javaCompiler.dependsOn("buildJS${variant.name.capitalize()}")
+        variant.javaCompiler.dependsOn("buildJS${variant.getBuildType().getName().capitalize()}")
     }
 }
 


### PR DESCRIPTION
Android build is broken post 0.17.6 release and webpack update. Fix the issue.

JIRA: None
Linked PRs: None

## Changes
- Use build type instead of variant name to call buildJS tasks.

## How to test-drive this PR
- Build and run android app

## TODOS:
- [x] Change works in both Android
- [ ] ~~CHANGELOG.md has been updated.~~
- [ ] ~~Run the generator to make sure it still functions correctly.~~
- [x] +1 from an engineer on the Astro team.
- [ ] ~~Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)~~

