### PR TITLE
Double Welcome Modal Fix

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -134,9 +134,8 @@ window.run = function() {
                 // The welcome modal can be configured to show only once
                 // (on first launch) by setting `{forced: false}` as the
                 // parameter for welcomeModalController.show()
-                welcomeModalController
-                    .show({forced: true})
-                    .finally(initMainLayout);
+                welcomeModalController.show({forced: true});
+                initMainLayout();
             });
     };
 
@@ -148,22 +147,6 @@ window.run = function() {
                     .then(runApp);
             });
     };
-
-    PreviewController.init().then(function(previewController) {
-        Application.on('previewToggled', function() {
-            previewController.presentPreviewAlert();
-        });
-
-        previewController.isPreviewEnabled().then(function(enabled) {
-            // Configure the previewEnabled flag located in baseConfig.js
-            // to enable/disable app preview
-            if (enabled && BaseConfig.previewEnabled) {
-                runAppPreview();
-            } else {
-                runApp();
-            }
-        });
-    });
 
     var initalizeAppWithAstroPreview = function() {
         PreviewController.init().then(function(previewController) {

--- a/webpack.app.config.js
+++ b/webpack.app.config.js
@@ -4,7 +4,7 @@ var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlug
 
 var rootDir = process.cwd();
 var entry = path.resolve(rootDir, 'app/app.js');
-var outDir = path.resolve(rootDir, 'build');
+var outDir = path.resolve(rootDir, 'app/build');
 
 var isProd = process.env.NODE_ENV === 'production';
 var analyzeBundle = process.env.NODE_ENV === 'Analyze';


### PR DESCRIPTION
This PR fixes a bug where the welcome modal would appear twice, one on top of each other. I also remove the waiting for the welcome modal to close before initing the main layout, because [Android supports that now](https://github.com/mobify/astro/pull/684)

JIRA: N/A
Linked PRs: 
- https://github.com/mobify/astro/pull/684

## Changes
- Remove double initialization of welcome modal

## How to test-drive this PR
- Run app on iOS and Android
- Welcome modal only appears once and can be closed

## TODOS:
- [x] Change works in both Android and iOS.

~~- [ ] CHANGELOG.md has been updated.~~
~~- [ ] Run the generator to make sure it still functions correctly.~~

- [x] +1 from an engineer on the Astro team.

~~- [ ] Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)~~

