### PR TITLE
🤘 Babel and Async/Await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": ["es2015"],
+  "plugins": [
+      "babel-plugin-syntax-async-functions",
+      ["transform-async-to-module-method", {
+        "module": "bluebird",
+        "method": "coroutine"
+      }],
+      ["transform-runtime", {
+        "polyfill": true,
+        "regenerator": true
+      }]
+    ]
+}

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,69 +1,9 @@
-env:
-  node: true
-  browser: true
-  amd: true
-  mocha: true
-  jquery: true
-  es6: true
-
-parserOptions:
-  sourceType: module
-
-globals:
-  Mobify: true
-  Zepto: true
-  Adaptive: true
-
+extends:
+  - './node_modules/mobify-code-style/es6/mobify-es6.yml'
+parser: 'babel-eslint'
 rules:
-  brace-style:
+  import/no-extraneous-dependencies: 'off'
+  semi:
     - error
-    - 1tbs
-    - allowSingleLine: true
-  eqeqeq: error
-  guard-for-in: error
-  no-extend-native: error
-  wrap-iife:
-    - error
-    - inside
-  no-use-before-define:
-    - error
-    - nofunc
-  new-cap: error
-  no-array-constructor: error
-  no-new-object: error
-  no-caller: error
-  no-empty: error
-  no-with: error
-  no-mixed-spaces-and-tabs: error
-  indent:
-    - error
-    - 4
-    - SwitchCase: 1
-  no-multi-str: error
-  camelcase: warn
-  no-trailing-spaces: error
-  comma-spacing: error
-  keyword-spacing: error
-  space-before-blocks: error
-  space-before-function-paren:
-    - error
-    - never
-  space-infix-ops: error
-  space-unary-ops: error
-  no-undef: error
-  eol-last: warn
-  quotes:
-    - error
-    - single
-  no-extra-semi: error
-  no-inner-declarations: error
-  max-depth:
-    - error
-    - max: 5
-  max-len:
-    - error
-    - code: 300
-      tabWidth: 4
-  semi: error
-  func-style: error
-  comma-style: error
+    - always
+  no-alert: 'off'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## To be released
+- ES6 and Async/Await Compatible with Babel
 - [Android] Update to Gradle 2.14, update project to Android Studio 2.2
 - [Android] Scaffold app only support handsets
 - [iOS] Enable install of preview-enabled and app store versions of generated apps

--- a/app/app-components/deepLinkingServices.js
+++ b/app/app-components/deepLinkingServices.js
@@ -1,6 +1,6 @@
 import Application from 'astro/application';
 
-var DeepLinkingServices = function(menuController) {
+const DeepLinkingServices = function(menuController) {
     this.menuController = menuController;
 
     this._bindStartUp();
@@ -8,23 +8,21 @@ var DeepLinkingServices = function(menuController) {
 };
 
 DeepLinkingServices.prototype._bindStartUp = function() {
-    var self = this;
-    Application.getStartUri().then(function(uri) {
+    Application.getStartUri().then((uri) => {
         if (uri !== null) {
-            self.menuController.navigateActiveItem(uri);
+            this.menuController.navigateActiveItem(uri);
         }
     });
 };
 
 DeepLinkingServices.prototype._bindRunning = function() {
-    var self = this;
     // Listen for deep link events once app is running
-    Application.on('receivedDeepLink', function(params) {
-        var uri = params.uri;
+    Application.on('receivedDeepLink', (params) => {
+        const uri = params.uri;
         if (uri !== null) {
-            self.menuController.navigateActiveItem(uri);
+            this.menuController.navigateActiveItem(uri);
         }
     });
 };
 
-module.exports = DeepLinkingServices;
+export default DeepLinkingServices;

--- a/app/app-config/baseConfig.js
+++ b/app/app-config/baseConfig.js
@@ -1,25 +1,25 @@
-var baseURL = 'https://webpush-you-host.mobifydemo.io';
+const baseURL = 'https://webpush-you-host.mobifydemo.io';
 
 // If any changes are made to the following lines
 // affected by the generator, make sure to update
 // the generator as well! 🙏🏻
 // start: lines altered by generator
-var useTabLayout = false;
-var previewBundle = '<preview_bundle>';
+const useTabLayout = false;
+const previewBundle = '<preview_bundle>';
 // end: lines altered by generator
 
-var colors = {
+const colors = {
     primaryColor: '#007ba7',
     secondaryColor: '#007ba7',
     whiteColor: '#ffffff'
 };
 
-var loaderColor = colors.primaryColor;
+const loaderColor = colors.primaryColor;
 
-module.exports = {
-    baseURL: baseURL,
-    colors: colors,
-    loaderColor: loaderColor,
-    previewBundle: previewBundle,
-    useTabLayout: useTabLayout
+export default {
+    baseURL,
+    colors,
+    loaderColor,
+    previewBundle,
+    useTabLayout
 };

--- a/app/app-config/cartConfig.js
+++ b/app/app-config/cartConfig.js
@@ -1,25 +1,25 @@
 import BaseConfig from './baseConfig';
 
-var url = 'https://webpush-you-host.mobifydemo.io/cart/';
+const url = 'https://webpush-you-host.mobifydemo.io/cart/';
 
-var headerContent = {
-    id : 'cartTitle_id',
+const headerContent = {
+    id: 'cartTitle_id',
     title: 'Cart'
 };
 
-var closeIcon = {
-    id : 'closeCart_id',
-    imageUrl : 'file:///icon__close.png'
+const closeIcon = {
+    id: 'closeCart_id',
+    imageUrl: 'file:///icon__close.png'
 };
 
-var colors = {
+const colors = {
     textColor: BaseConfig.colors.whiteColor,
     backgroundColor: BaseConfig.colors.primaryColor
 };
 
-module.exports = {
-    url : url,
-    headerContent : headerContent,
-    closeIcon : closeIcon,
-    colors: colors
+export default {
+    url,
+    headerContent,
+    closeIcon,
+    colors
 };

--- a/app/app-config/drawerMenuConfig.js
+++ b/app/app-config/drawerMenuConfig.js
@@ -4,63 +4,63 @@
 // ** Note: All leaf node items require an `href` key. The key value
 //          combined with the `baseURL` found in `baseConfig.js` will
 //          result in the complete URL used to navigate to the item.
-var menuItems = [
+const menuItems = [
     {
-        'title': 'Home',
-        'href': '/'
+        title: 'Home',
+        href: '/'
     },
     {
-        'title': 'Products',
-        'subItems': [
+        title: 'Products',
+        subItems: [
             {
-                'title': 'Bikes',
-                'subItems': [
+                title: 'Bikes',
+                subItems: [
                     {
-                        'title': 'Road Bike',
-                        'href':  '/bikes/road-bike'
+                        title: 'Road Bike',
+                        href: '/bikes/road-bike'
                     },
                     {
-                        'title': 'City Bike',
-                        'href': '/bikes/city-bike'
+                        title: 'City Bike',
+                        href: '/bikes/city-bike'
                     },
                     {
-                        'title': 'Commuter',
-                        'href': '/bikes/commuter'
+                        title: 'Commuter',
+                        href: '/bikes/commuter'
                     },
                     {
-                        'title': 'Fixie',
-                        'href': '/bikes/fixie'
+                        title: 'Fixie',
+                        href: '/bikes/fixie'
                     },
                     {
-                        'title': 'Hybrid',
-                        'href': '/bikes/hybrid'
+                        title: 'Hybrid',
+                        href: '/bikes/hybrid'
                     },
                     {
-                        'title': 'Mountain',
-                        'href': '/bikes/mountain'
+                        title: 'Mountain',
+                        href: '/bikes/mountain'
                     },
                 ]
             },
             {
-                'title': 'Accessories',
-                'href': '/accessories'
+                title: 'Accessories',
+                href: '/accessories'
             }
         ]
     },
     {
-        'title': 'Services',
-        'href': '/services'
+        title: 'Services',
+        href: '/services'
     },
     {
-        'title': 'Sales',
-        'href': '/sales'
+        title: 'Sales',
+        href: '/sales'
     },
     {
-        'title': 'About',
-        'href': '/about'
+        title: 'About',
+        href: '/about'
     },
 ];
 
-module.exports = {
-    menuItems: menuItems
+export default {
+    menuItems
 };

--- a/app/app-config/errorConfig.js
+++ b/app/app-config/errorConfig.js
@@ -1,4 +1,4 @@
-var url = 'file:///app-www/html/error.html';
+const url = 'file:///app-www/html/error.html';
 
 // Define/modify content for displayed error screens belonging to triggered
 // errors. Triggered errors are watched for in `errorController.js`.
@@ -9,23 +9,21 @@ var url = 'file:///app-www/html/error.html';
 //       thus `noInternetConnection` is the key for defining content.
 //
 //     - The value for the `imgSrc` key should be relative to `app-www/html/`
-var errors = {
+const errors = {
     noInternetConnection: {
         title: 'Connectivity Title',
-        text: 'To configure the contents of this error screen, '
-                + 'modify the app-config/errorConfig.js file.',
+        text: 'To configure the contents of this error screen, modify the app-config/errorConfig.js file.',
         imgSrc: '../assets/error__offline.png'
     },
 
     pageTimeout: {
         title: 'Timeout Title',
-        text: 'To configure the contents of this error screen,'
-                + 'modify the app-config/errorConfig.js file.',
+        text: 'To configure the contents of this error screen, modify the app-config/errorConfig.js file.',
         imgSrc: '../assets/error__timeout.png'
     }
 };
 
-module.exports = {
-    url : url,
-    errors: errors
+export default {
+    url,
+    errors
 };

--- a/app/app-config/headerConfig.js
+++ b/app/app-config/headerConfig.js
@@ -1,43 +1,43 @@
 import BaseConfig from './baseConfig';
 
-var cartHeaderContent = {
+const cartHeaderContent = {
     id: 'cart_id',
     imageUrl: 'file:///icon__cart.png'
 };
 
-var searchHeaderContent = {
+const searchHeaderContent = {
     id: 'search_id',
     imageUrl: 'file:///icon__search.png'
 };
 
-var drawerHeaderContent = {
+const drawerHeaderContent = {
     id: 'drawer_id',
     imageUrl: 'file:///icon__drawer.png'
 };
 
-var titleHeaderContent = {
+const titleHeaderContent = {
     id: 'header_id',
     title: 'Velo'
 };
 
-var cartTitleHeaderContent = {
+const cartTitleHeaderContent = {
     id: 'cartTitle_id',
     title: 'Cart'
 };
 
-var searchCartHeaderContent = {id: 'header__search_cart'};
+const searchCartHeaderContent = {id: 'header__search_cart'};
 
-var colors = {
+const colors = {
     textColor: BaseConfig.colors.whiteColor,
     backgroundColor: BaseConfig.colors.primaryColor
 };
 
-module.exports = {
-    cartHeaderContent: cartHeaderContent,
-    searchHeaderContent: searchHeaderContent,
-    drawerHeaderContent: drawerHeaderContent,
-    titleHeaderContent: titleHeaderContent,
-    cartTitleHeaderContent: cartTitleHeaderContent,
-    searchCartHeaderContent: searchCartHeaderContent,
-    colors: colors
+export default {
+    cartHeaderContent,
+    searchHeaderContent,
+    drawerHeaderContent,
+    titleHeaderContent,
+    cartTitleHeaderContent,
+    searchCartHeaderContent,
+    colors
 };

--- a/app/app-config/searchConfig.js
+++ b/app/app-config/searchConfig.js
@@ -1,7 +1,7 @@
-var uiSource = 'file:///app-www/html/search-bar.html';
-var queryUrl = 'http://www.google.com/search?q=<search_terms>';
+const uiSource = 'file:///app-www/html/search-bar.html';
+const queryUrl = 'http://www.google.com/search?q=<search_terms>';
 
-module.exports = {
-    uiSource : uiSource,
-    queryUrl: queryUrl
+export default {
+    uiSource,
+    queryUrl
 };

--- a/app/app-config/segmentsConfig.js
+++ b/app/app-config/segmentsConfig.js
@@ -1,4 +1,4 @@
-var segmentData = [
+const segmentData = [
     {
         id: 'bikes',
         url: '/',
@@ -29,4 +29,4 @@ var segmentData = [
     }
 ];
 
-module.exports = segmentData;
+export default segmentData;

--- a/app/app-config/tabConfig.js
+++ b/app/app-config/tabConfig.js
@@ -1,44 +1,44 @@
 import BaseConfig from './baseConfig';
 
 // Configure your tab bar items here:
-var tabItems = [
+const tabItems = [
     {
         id: '1',
-        title:'Bikes',
+        title: 'Bikes',
         url: BaseConfig.baseURL,
         imageUrl: 'file:///icon__discover.png',
         selectedImageUrl: 'file:///icon__discover.png'
     },
     {
         id: '2',
-        title:'Accessories',
-        url: BaseConfig.baseURL + '/accessories',
+        title: 'Accessories',
+        url: `${BaseConfig.baseURL}/accessories`,
         imageUrl: 'file:///icon__discover.png',
         selectedImageUrl: 'file:///icon__discover.png'
     },
     {
         id: '3',
-        title:'Services',
-        url: BaseConfig.baseURL + '/services',
+        title: 'Services',
+        url: `${BaseConfig.baseURL}/services`,
         imageUrl: 'file:///icon__discover.png',
         selectedImageUrl: 'file:///icon__discover.png'
     },
     {
         id: '4',
-        title:'Sales',
-        url: BaseConfig.baseURL + '/sales',
+        title: 'Sales',
+        url: `${BaseConfig.baseURL}/sales`,
         imageUrl: 'file:///icon__discover.png',
         selectedImageUrl: 'file:///icon__discover.png'
     },
     {
         id: '5',
-        title:'About',
-        url: BaseConfig.baseURL + '/about',
+        title: 'About',
+        url: `${BaseConfig.base}/about`,
         imageUrl: 'file:///icon__discover.png',
         selectedImageUrl: 'file:///icon__discover.png'
     }
 ];
 
-module.exports = {
-    tabItems: tabItems
+export default {
+    tabItems
 };

--- a/app/app-config/tabConfig.js
+++ b/app/app-config/tabConfig.js
@@ -33,7 +33,7 @@ const tabItems = [
     {
         id: '5',
         title: 'About',
-        url: `${BaseConfig.base}/about`,
+        url: `${BaseConfig.baseURL}/about`,
         imageUrl: 'file:///icon__discover.png',
         selectedImageUrl: 'file:///icon__discover.png'
     }

--- a/app/app-config/welcomeConfig.js
+++ b/app/app-config/welcomeConfig.js
@@ -1,28 +1,28 @@
 import BaseConfig from './baseConfig';
 
-var url = 'file:///app-www/html/welcome.html';
+const url = 'file:///app-www/html/welcome.html';
 
-var showHeader = false;
+const showHeader = false;
 
-var headerContent = {
-    id : 'welcomeTitle_id',
+const headerContent = {
+    id: 'welcomeTitle_id',
     title: 'Welcome'
 };
 
-var closeIcon = {
-    id : 'closeWelcome_id',
-    imageUrl : 'file:///icon__close.png'
+const closeIcon = {
+    id: 'closeWelcome_id',
+    imageUrl: 'file:///icon__close.png'
 };
 
-var colors = {
+const colors = {
     textColor: BaseConfig.colors.whiteColor,
     backgroundColor: BaseConfig.colors.primaryColor
 };
 
-module.exports = {
-    url : url,
-    showHeader: showHeader,
-    headerContent : headerContent,
-    closeIcon : closeIcon,
-    colors : colors
+export default {
+    url,
+    showHeader,
+    headerContent,
+    closeIcon,
+    colors
 };

--- a/app/app-controllers/cart/cartController.js
+++ b/app/app-controllers/cart/cartController.js
@@ -12,21 +12,25 @@ const CartController = function(headerController, layout, webView) {
     this.headerController = headerController;
 };
 
-CartController.init = function() {
-    return Promise.join(
+CartController.init = async function() {
+    const [
+        headerController,
+        layout,
+        webView
+    ] = await Promise.all([
         CartHeaderController.init(),
         AnchoredLayoutPlugin.init(),
-        WebViewPlugin.init(),
-    (headerController, layout, webView) => {
-        const loader = webView.getLoader();
-        loader.setColor(BaseConfig.loaderColor);
-        webView.navigate(CartConfig.url);
+        WebViewPlugin.init()
+    ]);
 
-        layout.addTopView(headerController.viewPlugin);
-        layout.setContentView(webView);
+    const loader = webView.getLoader();
+    loader.setColor(BaseConfig.loaderColor);
+    webView.navigate(CartConfig.url);
 
-        return new CartController(headerController, layout, webView);
-    });
+    layout.addTopView(headerController.viewPlugin);
+    layout.setContentView(webView);
+
+    return new CartController(headerController, layout, webView);
 };
 
 CartController.prototype.registerCloseEventHandler = function(callback) {

--- a/app/app-controllers/cart/cartController.js
+++ b/app/app-controllers/cart/cartController.js
@@ -1,12 +1,11 @@
 import Promise from 'bluebird';
 import WebViewPlugin from 'astro/plugins/webViewPlugin';
 import AnchoredLayoutPlugin from 'astro/plugins/anchoredLayoutPlugin';
-import DefaultLoaderPlugin from 'astro/plugins/loaders/defaultLoaderPlugin';
 import BaseConfig from '../../app-config/baseConfig';
 import CartConfig from '../../app-config/cartConfig';
 import CartHeaderController from './cartHeaderController';
 
-var CartController = function(headerController, layout, webView) {
+const CartController = function(headerController, layout, webView) {
     this.viewPlugin = layout;
 
     this.webView = webView;
@@ -14,13 +13,12 @@ var CartController = function(headerController, layout, webView) {
 };
 
 CartController.init = function() {
-    var webViewPromise = WebViewPlugin.init();
     return Promise.join(
         CartHeaderController.init(),
         AnchoredLayoutPlugin.init(),
         WebViewPlugin.init(),
-    function(headerController, layout, webView) {
-        var loader = webView.getLoader();
+    (headerController, layout, webView) => {
+        const loader = webView.getLoader();
         loader.setColor(BaseConfig.loaderColor);
         webView.navigate(CartConfig.url);
 
@@ -50,4 +48,4 @@ CartController.prototype.back = function() {
     return this.webView.back();
 };
 
-module.exports = CartController;
+export default CartController;

--- a/app/app-controllers/cart/cartHeaderController.js
+++ b/app/app-controllers/cart/cartHeaderController.js
@@ -5,23 +5,23 @@ const CartHeaderController = function(headerBar) {
     this.viewPlugin = headerBar;
 };
 
-CartHeaderController.init = function() {
-    return HeaderBarPlugin.init().then((headerBar) => {
-        headerBar.setTextColor(CartConfig.colors.textColor);
-        headerBar.setBackgroundColor(CartConfig.colors.backgroundColor);
+CartHeaderController.init = async function() {
+    const headerBar = await HeaderBarPlugin.init();
 
-        headerBar.setCenterTitle(
-            CartConfig.headerContent.title,
-            CartConfig.headerContent.id
-        );
+    headerBar.setTextColor(CartConfig.colors.textColor);
+    headerBar.setBackgroundColor(CartConfig.colors.backgroundColor);
 
-        headerBar.setRightIcon(
-            CartConfig.closeIcon.imageUrl,
-            CartConfig.closeIcon.id
-        );
+    headerBar.setCenterTitle(
+        CartConfig.headerContent.title,
+        CartConfig.headerContent.id
+    );
 
-        return new CartHeaderController(headerBar);
-    });
+    headerBar.setRightIcon(
+        CartConfig.closeIcon.imageUrl,
+        CartConfig.closeIcon.id
+    );
+
+    return new CartHeaderController(headerBar);
 };
 
 CartHeaderController.prototype.registerCloseEventHandler = function(callback) {

--- a/app/app-controllers/cart/cartHeaderController.js
+++ b/app/app-controllers/cart/cartHeaderController.js
@@ -1,13 +1,12 @@
-import Promise from 'bluebird';
 import HeaderBarPlugin from 'astro/plugins/headerBarPlugin';
 import CartConfig from '../../app-config/cartConfig';
 
-var CartHeaderController = function(headerBar) {
+const CartHeaderController = function(headerBar) {
     this.viewPlugin = headerBar;
 };
 
 CartHeaderController.init = function() {
-    return HeaderBarPlugin.init().then(function(headerBar) {
+    return HeaderBarPlugin.init().then((headerBar) => {
         headerBar.setTextColor(CartConfig.colors.textColor);
         headerBar.setBackgroundColor(CartConfig.colors.backgroundColor);
 
@@ -30,7 +29,7 @@ CartHeaderController.prototype.registerCloseEventHandler = function(callback) {
         return;
     }
 
-    this.viewPlugin.on('click:' + CartConfig.closeIcon.id, callback);
+    this.viewPlugin.on(`click:${CartConfig.closeIcon.id}`, callback);
 };
 
-module.exports = CartHeaderController;
+export default CartHeaderController;

--- a/app/app-controllers/cart/cartModalController.js
+++ b/app/app-controllers/cart/cartModalController.js
@@ -20,54 +20,56 @@ const CartModalController = function(modalView, cartController) {
     };
 };
 
-CartModalController.init = function(errorControllerPromise) {
-    return Promise.join(
+CartModalController.init = async function(errorController) {
+    const [
+        cartController,
+        modalView
+    ] = await Promise.all([
         CartController.init(),
-        ModalViewPlugin.init(),
-        errorControllerPromise,
-    (cartController, modalView, errorController) => {
-        modalView.setContentView(cartController.viewPlugin);
+        ModalViewPlugin.init()
+    ]);
 
-        const cartModalController = new CartModalController(modalView, cartController);
-        cartController.registerCloseEventHandler(() => {
-            cartModalController.hide();
-        });
+    modalView.setContentView(cartController.viewPlugin);
 
-        // Register RPC methods
-        Astro.registerRpcMethod(AppRpc.names.cartShow, [], () => {
-            cartModalController.show();
-        });
-        Astro.registerRpcMethod(AppRpc.names.cartHide, [], () => {
-            cartModalController.hide();
-        });
-
-        const backHandler = function() {
-            cartModalController.hide();
-        };
-
-        const retryHandler = function(params) {
-            if (!params.url) {
-                return;
-            }
-            cartController.navigate(params.url);
-        };
-
-        // Modals will always be able to go back. At it's root, the modal
-        // will dismiss.
-        const canGoBack = function() {
-            return Promise.resolve(true);
-        };
-
-        errorController.bindToNavigator({
-            navigator: cartController.webView,
-            backHandler,
-            retryHandler,
-            isActiveItem: cartModalController.isActiveItem.bind(cartModalController),
-            canGoBack
-        });
-
-        return cartModalController;
+    const cartModalController = new CartModalController(modalView, cartController);
+    cartController.registerCloseEventHandler(() => {
+        cartModalController.hide();
     });
+
+    // Register RPC methods
+    Astro.registerRpcMethod(AppRpc.names.cartShow, [], () => {
+        cartModalController.show();
+    });
+    Astro.registerRpcMethod(AppRpc.names.cartHide, [], () => {
+        cartModalController.hide();
+    });
+
+    const backHandler = function() {
+        cartModalController.hide();
+    };
+
+    const retryHandler = function(params) {
+        if (!params.url) {
+            return;
+        }
+        cartController.navigate(params.url);
+    };
+
+    // Modals will always be able to go back. At it's root, the modal
+    // will dismiss.
+    const canGoBack = function() {
+        return Promise.resolve(true);
+    };
+
+    errorController.bindToNavigator({
+        navigator: cartController.webView,
+        backHandler,
+        retryHandler,
+        isActiveItem: cartModalController.isActiveItem.bind(cartModalController),
+        canGoBack
+    });
+
+    return cartModalController;
 };
 
 CartModalController.prototype.show = function() {

--- a/app/app-controllers/cart/cartModalController.js
+++ b/app/app-controllers/cart/cartModalController.js
@@ -5,7 +5,7 @@ import AppEvents from '../../global/app-events';
 import AppRpc from '../../global/app-rpc';
 import CartController from './cartController';
 
-var CartModalController = function(modalView, cartController) {
+const CartModalController = function(modalView, cartController) {
     this.isShowing = false;
     this.viewPlugin = modalView;
     this.cartController = cartController;
@@ -25,27 +25,27 @@ CartModalController.init = function(errorControllerPromise) {
         CartController.init(),
         ModalViewPlugin.init(),
         errorControllerPromise,
-    function(cartController, modalView, errorController) {
+    (cartController, modalView, errorController) => {
         modalView.setContentView(cartController.viewPlugin);
 
-        var cartModalController = new CartModalController(modalView, cartController);
-        cartController.registerCloseEventHandler(function() {
+        const cartModalController = new CartModalController(modalView, cartController);
+        cartController.registerCloseEventHandler(() => {
             cartModalController.hide();
         });
 
         // Register RPC methods
-        Astro.registerRpcMethod(AppRpc.names.cartShow, [], function(res) {
+        Astro.registerRpcMethod(AppRpc.names.cartShow, [], () => {
             cartModalController.show();
         });
-        Astro.registerRpcMethod(AppRpc.names.cartHide, [], function(res) {
+        Astro.registerRpcMethod(AppRpc.names.cartHide, [], () => {
             cartModalController.hide();
         });
 
-        var backHandler = function() {
+        const backHandler = function() {
             cartModalController.hide();
         };
 
-        var retryHandler = function(params) {
+        const retryHandler = function(params) {
             if (!params.url) {
                 return;
             }
@@ -54,16 +54,16 @@ CartModalController.init = function(errorControllerPromise) {
 
         // Modals will always be able to go back. At it's root, the modal
         // will dismiss.
-        var canGoBack = function() {
+        const canGoBack = function() {
             return Promise.resolve(true);
         };
 
         errorController.bindToNavigator({
             navigator: cartController.webView,
-            backHandler: backHandler,
-            retryHandler: retryHandler,
+            backHandler,
+            retryHandler,
             isActiveItem: cartModalController.isActiveItem.bind(cartModalController),
-            canGoBack: canGoBack
+            canGoBack
         });
 
         return cartModalController;
@@ -98,4 +98,4 @@ CartModalController.prototype.isActiveItem = function() {
     return this.isShowing;
 };
 
-module.exports = CartModalController;
+export default CartModalController;

--- a/app/app-controllers/doubleIconsController.js
+++ b/app/app-controllers/doubleIconsController.js
@@ -3,17 +3,17 @@ import Astro from 'astro/astro-full';
 import BackboneEvents from 'vendor/backbone-events';
 import DoubleIconsPlugin from '../app-plugins/doubleIconsPlugin';
 
-var DoubleIconsController = function(headerId, generateLeftIcon, generateRightIcon) {
+const DoubleIconsController = function(headerId, generateLeftIcon, generateRightIcon) {
     this.headerId = headerId;
     this.generateLeftIcon = generateLeftIcon;
     this.generateRightIcon = generateRightIcon;
 };
 
-var _setLeftIcon = function(doubleIcons, address) {
+const _setLeftIcon = function(doubleIcons, address) {
     doubleIcons.setLeftIcon(address);
 };
 
-var _setRightIcon = function(doubleIcons, address) {
+const _setRightIcon = function(doubleIcons, address) {
     doubleIcons.setRightIcon(address);
 };
 
@@ -24,17 +24,12 @@ DoubleIconsController.prototype._createDoubleIcons = function(doubleIcons) {
     // registers for an event which gets triggered when the function for
     // generating new plugins for that icon changes
     // (ie. icon is being changed to display a different image)
-    this.on('updateLeftIcon', function(param) {
-        _setLeftIcon(doubleIcons, param.generateLeftIcon());
-    });
-
-    this.on('updateRightIcon', function(param) {
-        _setRightIcon(doubleIcons, param.generateRightIcon());
-    });
+    this.on('updateLeftIcon', (param) => _setLeftIcon(doubleIcons, param.generateLeftIcon()));
+    this.on('updateRightIcon', (param) => _setRightIcon(doubleIcons, param.generateRightIcon()));
 
     return Promise.join(this.generateLeftIcon(),
                         this.generateRightIcon(),
-        function(leftIcon, rightIcon) {
+        (leftIcon, rightIcon) => {
             _setLeftIcon(doubleIcons, leftIcon);
             _setRightIcon(doubleIcons, rightIcon);
         });
@@ -48,21 +43,13 @@ DoubleIconsController.prototype._createDoubleIconHeaderContent = function(double
 };
 
 DoubleIconsController.prototype.generateContent = function() {
-    var self = this;
+    const self = this;
 
     return DoubleIconsPlugin.init().then(
-        function(doubleIcons) {
-            doubleIcons.on('click:doubleIcons_left', function(param) {
-                self.trigger('click:doubleIcons_left', param);
-            });
-
-            doubleIcons.on('click:doubleIcons_right', function(param) {
-                self.trigger('click:doubleIcons_right', param);
-            });
-
-            return self._createDoubleIcons(doubleIcons).then(function() {
-                return self._createDoubleIconHeaderContent(doubleIcons);
-            });
+        (doubleIcons) => {
+            doubleIcons.on('click:doubleIcons_left', (param) => self.trigger('click:doubleIcons_left', param));
+            doubleIcons.on('click:doubleIcons_right', (param) => self.trigger('click:doubleIcons_right', param));
+            return self._createDoubleIcons(doubleIcons).then(() => self._createDoubleIconHeaderContent(doubleIcons));
         }
    );
 };
@@ -80,10 +67,10 @@ DoubleIconsController.prototype.updateGenerateRightIcon = function(generateRight
 };
 
 DoubleIconsController.init = function(headerId, generateLeftIcon, generateRightIcon) {
-    var doubleIconsController = new DoubleIconsController(headerId, generateLeftIcon, generateRightIcon);
+    let doubleIconsController = new DoubleIconsController(headerId, generateLeftIcon, generateRightIcon);
     doubleIconsController = Astro.Utils.extend(doubleIconsController, BackboneEvents);
 
     return Promise.resolve(doubleIconsController);
 };
 
-module.exports = DoubleIconsController;
+export default DoubleIconsController;

--- a/app/app-controllers/drawerController.js
+++ b/app/app-controllers/drawerController.js
@@ -7,14 +7,14 @@ import DrawerMenuConfig from '../app-config/drawerMenuConfig';
 import AppRpc from '../global/app-rpc';
 import NavigationController from './navigationController';
 
-var DrawerController = function(drawer, leftMenu, navigationController) {
+const DrawerController = function(drawer, leftMenu, navigationController) {
     this.drawer = drawer;
     this.leftMenu = leftMenu;
     this.navigationController = navigationController;
 };
 
-var initLeftMenu = function(drawer, leftMenu) {
-    Astro.registerRpcMethod(AppRpc.names.menuItems, [], function(res) {
+const initLeftMenu = function(drawer, leftMenu) {
+    Astro.registerRpcMethod(AppRpc.names.menuItems, [], (res) => {
         res.send(null, DrawerMenuConfig.menuItems);
     });
 
@@ -25,14 +25,14 @@ var initLeftMenu = function(drawer, leftMenu) {
     return drawer;
 };
 
-var initNavigationController = function(drawer, counterBadgeController, cartEventHandler, errorController) {
-    var drawerEventHandler = function() {
+const initNavigationController = function(drawer, counterBadgeController, cartEventHandler, errorController) {
+    const drawerEventHandler = function() {
         drawer.showLeftMenu();
     };
 
     // The navigationController requires an id. Since we are using a drawer
     // layout, we have 1 main navigation plugin -- thus its ID is set to 1.
-    var controllerID = 1;
+    const controllerID = 1;
     return NavigationController.init(
         controllerID,
         BaseConfig.baseURL,
@@ -43,14 +43,14 @@ var initNavigationController = function(drawer, counterBadgeController, cartEven
 };
 
 DrawerController.init = function(counterBadgeControllerPromise, cartEventHandlerPromise, errorControllerPromise) {
-    var webViewPromise = WebViewPlugin.init();
+    const webViewPromise = WebViewPlugin.init();
 
-    var initLeftMenuPromise = Promise.join(
+    const initLeftMenuPromise = Promise.join(
         DrawerPlugin.init(),
         webViewPromise,
         initLeftMenu);
 
-    var initNavigationControllerPromise = Promise.join(
+    const initNavigationControllerPromise = Promise.join(
         initLeftMenuPromise,
         counterBadgeControllerPromise,
         cartEventHandlerPromise,
@@ -61,13 +61,13 @@ DrawerController.init = function(counterBadgeControllerPromise, cartEventHandler
         initLeftMenuPromise,
         initNavigationControllerPromise,
         webViewPromise,
-    function(drawer, navigationController, leftMenu) {
+    (drawer, navigationController, leftMenu) => {
         navigationController.isActive = true;
         leftMenu.disableDefaultNavigationHandler();
         drawer.setContentView(navigationController.viewPlugin);
-        var drawerController = new DrawerController(drawer, leftMenu, navigationController);
+        const drawerController = new DrawerController(drawer, leftMenu, navigationController);
 
-        Astro.registerRpcMethod(AppRpc.names.renderLeftMenu, ['menuItems'], function(res, menuItems) {
+        Astro.registerRpcMethod(AppRpc.names.renderLeftMenu, ['menuItems'], (res, menuItems) => {
             drawerController.renderLeftMenu(menuItems);
         });
 
@@ -85,19 +85,19 @@ DrawerController.prototype.navigateToNewRootView = function(url, title) {
 };
 
 DrawerController.prototype.backActiveItem = function() {
-    var activeItem = this.navigationController;
+    const activeItem = this.navigationController;
     activeItem.back();
 };
 
 DrawerController.prototype.canGoBack = function() {
-    var activeItem = this.navigationController;
+    const activeItem = this.navigationController;
     return activeItem.canGoBack();
 };
 
 // This method is used to re-render the left menu after it has already
 // been initialized.
 DrawerController.prototype.renderLeftMenu = function(menuItems) {
-    this.leftMenu.trigger('setMenuItems', {menuItems: menuItems});
+    this.leftMenu.trigger('setMenuItems', {menuItems});
 };
 
-module.exports = DrawerController;
+export default DrawerController;

--- a/app/app-controllers/error-screen/errorController.js
+++ b/app/app-controllers/error-screen/errorController.js
@@ -16,17 +16,20 @@ const ErrorController = function(modalView, webView) {
     this.viewPlugin.navigate(ErrorConfig.url);
 };
 
-ErrorController.init = function() {
-    return Promise.join(
+ErrorController.init = async function() {
+    const [
+        webView,
+        modalView
+    ] = await Promise.all([
         WebViewPlugin.init(),
-        ModalViewPlugin.init(),
-    (webView, modalView) => {
-        webView.getLoader().setColor(BaseConfig.loaderColor);
-        webView.disableScrollBounce();
-        modalView.setContentView(webView);
+        ModalViewPlugin.init()
+    ]);
 
-        return new ErrorController(modalView, webView);
-    });
+    webView.getLoader().setColor(BaseConfig.loaderColor);
+    webView.disableScrollBounce();
+    modalView.setContentView(webView);
+
+    return new ErrorController(modalView, webView);
 };
 
 ErrorController.prototype.handleHardwareBackButtonPress = function() {

--- a/app/app-controllers/error-screen/errorController.js
+++ b/app/app-controllers/error-screen/errorController.js
@@ -1,11 +1,10 @@
 import Promise from 'bluebird';
-import Astro from 'astro/astro-full';
 import WebViewPlugin from 'astro/plugins/webViewPlugin';
 import ModalViewPlugin from 'astro/plugins/modalViewPlugin';
 import ErrorConfig from '../../app-config/errorConfig';
 import BaseConfig from '../../app-config/baseConfig';
 
-var ErrorController = function(modalView, webView) {
+const ErrorController = function(modalView, webView) {
     this.isShowing = false;
     this.viewPlugin = webView;
     this.modalView = modalView;
@@ -21,7 +20,7 @@ ErrorController.init = function() {
     return Promise.join(
         WebViewPlugin.init(),
         ModalViewPlugin.init(),
-    function(webView, modalView) {
+    (webView, modalView) => {
         webView.getLoader().setColor(BaseConfig.loaderColor);
         webView.disableScrollBounce();
         modalView.setContentView(webView);
@@ -52,7 +51,7 @@ ErrorController.prototype.errorContent = function() {
         return null;
     }
 
-    var errorContent = ErrorConfig.errors[this.errorType];
+    const errorContent = ErrorConfig.errors[this.errorType];
     errorContent.canGoBack = this.canGoBack;
 
     return errorContent;
@@ -67,12 +66,12 @@ ErrorController.prototype._removeModalEvents = function() {
 };
 
 ErrorController.prototype._generateErrorCallback = function(params) {
-    var self = this;
-    var navigator = params.navigator;
-    var backHandler = params.backHandler;
-    var retryHandler = params.retryHandler;
-    var isActiveItem = params.isActiveItem;
-    var canGoBack = params.canGoBack;
+    const self = this;
+    const navigator = params.navigator;
+    const backHandler = params.backHandler;
+    const retryHandler = params.retryHandler;
+    const isActiveItem = params.isActiveItem;
+    const canGoBack = params.canGoBack;
 
     return function(eventArgs) {
         navigator.loaded = false;
@@ -86,7 +85,7 @@ ErrorController.prototype._generateErrorCallback = function(params) {
         // Only trigger the error modal if the active navigation view is
         // the one that failed to load.
         if (isActiveItem()) {
-            self.viewPlugin.once('back', function() {
+            self.viewPlugin.once('back', () => {
                 if (self.canGoBack) {
                     self.hide();
                     self._removeModalEvents();
@@ -95,13 +94,13 @@ ErrorController.prototype._generateErrorCallback = function(params) {
             });
 
             // Wait until the error page is loaded before showing
-            self.viewPlugin.on('astro:page-loaded', function() {
+            self.viewPlugin.on('astro:page-loaded', () => {
                 self.show();
             });
 
-            canGoBack().then(function(canGoBack) {
+            canGoBack().then((canGoBack) => {
                 self.canGoBack = canGoBack;
-                var loadParams = {
+                const loadParams = {
                     errorContent: self.errorContent()
                 };
                 self.viewPlugin.trigger('error:should-load', loadParams);
@@ -111,7 +110,7 @@ ErrorController.prototype._generateErrorCallback = function(params) {
         // We allow all views that triggered this modal to listen for
         // `retry` so that they will reload when the error modal's retry
         // button is pressed
-        self.viewPlugin.once('retry', function() {
+        self.viewPlugin.once('retry', () => {
             self.hide();
             self._removeModalEvents();
             retryHandler(eventArgs);
@@ -120,10 +119,10 @@ ErrorController.prototype._generateErrorCallback = function(params) {
 };
 
 ErrorController.prototype.bindToNavigator = function(params) {
-    var navigator = params.navigator;
+    const navigator = params.navigator;
 
     // Listen for triggered events emitted by the navigator
     navigator.on('navigationFailed', this._generateErrorCallback(params));
 };
 
-module.exports = ErrorController;
+export default ErrorController;

--- a/app/app-controllers/navigationController.js
+++ b/app/app-controllers/navigationController.js
@@ -13,7 +13,7 @@ const bindEvents = function(self) {
     const handleActiveState = (event) => {
         if (self.isActive) {
             AppEvents.once(event, () => {
-                self.isActive = true
+                self.isActive = true;
             });
         }
         self.isActive = false;

--- a/app/app-controllers/navigationController.js
+++ b/app/app-controllers/navigationController.js
@@ -9,14 +9,14 @@ import NavigationHeaderController from './navigationHeaderController';
 import SearchBarController from './searchBarController';
 import SegmentedController from './segmentedController';
 
-const bindEvents = function() {
+const bindEvents = function(self) {
     const handleActiveState = (event) => {
-        if (this.isActive) {
-            AppEvents.once(event, function() {
-                this.isActive = true;
+        if (self.isActive) {
+            AppEvents.once(event, () => {
+                self.isActive = true
             });
         }
-        this.isActive = false;
+        self.isActive = false;
     };
 
     AppEvents.on(AppEvents.names.welcomeShown, () => handleActiveState(AppEvents.names.welcomeHidden));

--- a/app/app-controllers/navigationHeaderController.js
+++ b/app/app-controllers/navigationHeaderController.js
@@ -13,46 +13,46 @@ const _createDrawerHeaderContent = function() {
     return HeaderConfig.drawerHeaderContent;
 };
 
-NavigationHeaderController.init = function(counterBadgeController) {
-    const generateSearchIcon = function() {
-        return ImageViewPlugin.init().then((searchIcon) => {
-            searchIcon.setImagePath(HeaderConfig.searchHeaderContent.imageUrl);
-            return searchIcon;
-        });
+NavigationHeaderController.init = async function(counterBadgeController) {
+    const generateSearchIcon = async function() {
+        const searchIcon = await ImageViewPlugin.init();
+        searchIcon.setImagePath(HeaderConfig.searchHeaderContent.imageUrl);
+        return searchIcon;
     };
+    const generateCartIcon = counterBadgeController.generatePlugin.bind(counterBadgeController);
 
-    const generateCartIcon =
-        counterBadgeController.generatePlugin.bind(counterBadgeController);
-
-    return Promise.join(
+    const [
+        headerBar,
+        doubleIconsController
+    ] = await Promise.all([
         HeaderBarPlugin.init(),
         DoubleIconsController.init(
             HeaderConfig.searchCartHeaderContent.id,
             generateSearchIcon,
-            generateCartIcon),
-    (headerBar, doubleIconsController) => {
-        headerBar.hideBackButtonText();
-        headerBar.setTextColor(HeaderConfig.colors.textColor);
-        headerBar.setBackgroundColor(HeaderConfig.colors.backgroundColor);
+            generateCartIcon
+        )
+    ]);
 
-        return new NavigationHeaderController(headerBar, doubleIconsController);
-    });
+    headerBar.hideBackButtonText();
+    headerBar.setTextColor(HeaderConfig.colors.textColor);
+    headerBar.setBackgroundColor(HeaderConfig.colors.backgroundColor);
+
+    return new NavigationHeaderController(headerBar, doubleIconsController);
 };
 
-NavigationHeaderController.prototype.generateContent = function(includeDrawer) {
-    return this.doubleIconsController.generateContent().then((doubleIconsHeaderContent) => {
-        const headerContent = {
-            header: {
-                rightIcon: doubleIconsHeaderContent
-            }
-        };
-
-        if (includeDrawer !== undefined && includeDrawer) {
-            headerContent.header.leftIcon = _createDrawerHeaderContent();
+NavigationHeaderController.prototype.generateContent = async function(includeDrawer) {
+    const doubleIconsHeaderContent = await this.doubleIconsController.generateContent();
+    const headerContent = {
+        header: {
+            rightIcon: doubleIconsHeaderContent
         }
+    };
 
-        return headerContent;
-    });
+    if (includeDrawer !== undefined && includeDrawer) {
+        headerContent.header.leftIcon = _createDrawerHeaderContent();
+    }
+
+    return headerContent;
 };
 
 NavigationHeaderController.prototype.registerBackEvents = function(callback) {

--- a/app/app-controllers/navigationHeaderController.js
+++ b/app/app-controllers/navigationHeaderController.js
@@ -4,24 +4,24 @@ import ImageViewPlugin from 'astro/plugins/imageViewPlugin';
 import HeaderConfig from '../app-config/headerConfig';
 import DoubleIconsController from './doubleIconsController';
 
-var NavigationHeaderController = function(headerBar, doubleIconsController) {
+const NavigationHeaderController = function(headerBar, doubleIconsController) {
     this.viewPlugin = headerBar;
     this.doubleIconsController = doubleIconsController;
 };
 
-var _createDrawerHeaderContent = function() {
+const _createDrawerHeaderContent = function() {
     return HeaderConfig.drawerHeaderContent;
 };
 
 NavigationHeaderController.init = function(counterBadgeController) {
-    var generateSearchIcon = function() {
-        return ImageViewPlugin.init().then(function(searchIcon) {
+    const generateSearchIcon = function() {
+        return ImageViewPlugin.init().then((searchIcon) => {
             searchIcon.setImagePath(HeaderConfig.searchHeaderContent.imageUrl);
             return searchIcon;
         });
     };
 
-    var generateCartIcon =
+    const generateCartIcon =
         counterBadgeController.generatePlugin.bind(counterBadgeController);
 
     return Promise.join(
@@ -30,7 +30,7 @@ NavigationHeaderController.init = function(counterBadgeController) {
             HeaderConfig.searchCartHeaderContent.id,
             generateSearchIcon,
             generateCartIcon),
-    function(headerBar, doubleIconsController) {
+    (headerBar, doubleIconsController) => {
         headerBar.hideBackButtonText();
         headerBar.setTextColor(HeaderConfig.colors.textColor);
         headerBar.setBackgroundColor(HeaderConfig.colors.backgroundColor);
@@ -40,8 +40,8 @@ NavigationHeaderController.init = function(counterBadgeController) {
 };
 
 NavigationHeaderController.prototype.generateContent = function(includeDrawer) {
-    return this.doubleIconsController.generateContent().then(function(doubleIconsHeaderContent) {
-        var headerContent = {
+    return this.doubleIconsController.generateContent().then((doubleIconsHeaderContent) => {
+        const headerContent = {
             header: {
                 rightIcon: doubleIconsHeaderContent
             }
@@ -68,7 +68,7 @@ NavigationHeaderController.prototype.registerDrawerEvents = function(callback) {
         return;
     }
 
-    this.viewPlugin.on('click:' + HeaderConfig.drawerHeaderContent.id, callback);
+    this.viewPlugin.on(`click:${HeaderConfig.drawerHeaderContent.id}`, callback);
 };
 
 NavigationHeaderController.prototype.registerSearchBarEvents = function(callback) {
@@ -88,8 +88,8 @@ NavigationHeaderController.prototype.registerCartEvents = function(callback) {
 };
 
 NavigationHeaderController.prototype.setTitle = function() {
-    var titleHeaderContent = HeaderConfig.titleHeaderContent;
+    const titleHeaderContent = HeaderConfig.titleHeaderContent;
     return this.viewPlugin.setCenterTitle(titleHeaderContent.title, titleHeaderContent.id);
 };
 
-module.exports = NavigationHeaderController;
+export default NavigationHeaderController;

--- a/app/app-controllers/searchBarController.js
+++ b/app/app-controllers/searchBarController.js
@@ -1,4 +1,3 @@
-import Promise from 'bluebird';
 import Astro from 'astro/astro-full';
 import SearchBarPlugin from 'astro/plugins/searchBarPlugin';
 import AnchoredLayoutPlugin from 'astro/plugins/anchoredLayoutPlugin';
@@ -20,13 +19,11 @@ const SearchBarController = function(internalLayout, parentLayout, searchBarPlug
     this._registerEvents();
 };
 
-SearchBarController.init = function(layoutPromise, searchConfig) {
-    return Promise.join(AnchoredLayoutPlugin.init(), layoutPromise, SearchBarPlugin.init(),
-        (internalLayout, parentLayout, searchBarPlugin) => {
-            internalLayout.addTopView(searchBarPlugin);
-            return new SearchBarController(internalLayout, parentLayout, searchBarPlugin, searchConfig);
-        }
-    );
+SearchBarController.init = async function(parentLayout, searchConfig) {
+    const internalLayout = await AnchoredLayoutPlugin.init();
+    const searchBarPlugin = await SearchBarPlugin.init();
+    internalLayout.addTopView(searchBarPlugin);
+    return new SearchBarController(internalLayout, parentLayout, searchBarPlugin, searchConfig);
 };
 
 // Returns queryUrl with the string "<search_terms>" replaced with the

--- a/app/app-controllers/searchBarController.js
+++ b/app/app-controllers/searchBarController.js
@@ -3,7 +3,7 @@ import Astro from 'astro/astro-full';
 import SearchBarPlugin from 'astro/plugins/searchBarPlugin';
 import AnchoredLayoutPlugin from 'astro/plugins/anchoredLayoutPlugin';
 
-var SearchBarController = function(internalLayout, parentLayout, searchBarPlugin, searchConfig) {
+const SearchBarController = function(internalLayout, parentLayout, searchBarPlugin, searchConfig) {
     this.viewPlugin = internalLayout;
     this.parentLayout = parentLayout;
     this.searchBar = searchBarPlugin;
@@ -22,7 +22,7 @@ var SearchBarController = function(internalLayout, parentLayout, searchBarPlugin
 
 SearchBarController.init = function(layoutPromise, searchConfig) {
     return Promise.join(AnchoredLayoutPlugin.init(), layoutPromise, SearchBarPlugin.init(),
-        function(internalLayout, parentLayout, searchBarPlugin) {
+        (internalLayout, parentLayout, searchBarPlugin) => {
             internalLayout.addTopView(searchBarPlugin);
             return new SearchBarController(internalLayout, parentLayout, searchBarPlugin, searchConfig);
         }
@@ -42,18 +42,12 @@ SearchBarController.prototype.addToLayout = function() {
 };
 
 SearchBarController.prototype._registerEvents = function() {
-    var self = this;
     // Users of SearchBarController can also hook this event
     // to instruct the desired view to act on the search being performed
     // The search terms are expected to be in a string found in
     // params['searchTerms']
-    this.searchBar.on('search:submitted', function(params) {
-        self.hide();
-    });
-
-    this.searchBar.on('search:cancelled', function(params) {
-        self.hide();
-    });
+    this.searchBar.on('search:submitted', () => this.hide());
+    this.searchBar.on('search:cancelled', () => this.hide());
 };
 
 SearchBarController.prototype.show = function(options) {
@@ -95,4 +89,4 @@ SearchBarController.prototype.registerSearchSubmittedEvents = function(callback)
     this.searchBar.on('search:submitted', callback);
 };
 
-module.exports = SearchBarController;
+export default SearchBarController;

--- a/app/app-controllers/segmentedController.js
+++ b/app/app-controllers/segmentedController.js
@@ -11,31 +11,25 @@ const SegmentedController = function(layout, navigationView, urlMap) {
     this._registerEvents();
 };
 
-SegmentedController.init = function(layoutPromise, navigationViewPromise) {
+SegmentedController.init = async function(layout, navigationView) {
     const urlMap = {};
-    return Promise.join(
-        layoutPromise,
-        navigationViewPromise,
-        (layout, navigationView) => {
-            return Promise.all(
-                SegmentsConfig.map((page) => {
-                    return SegmentedPlugin.init().then((segmentedControl) => {
-                        segmentedControl.setColor(BaseConfig.colors.primaryColor);
-                        segmentedControl.setItems(page.items);
-                        // eslint-disable-next-line
-                        segmentedControl.on('itemSelect', (params) => navigationView.trigger(`segmented:${params.key}`));
-                        layout.addTopView(segmentedControl, {
-                            animated: false,
-                            visible: false
-                        });
-                        urlMap[page.url] = segmentedControl;
-                    });
-                })
-            ).then(() => {
-                return new SegmentedController(layout, navigationView, urlMap);
+
+    const segmentConfigPromises = SegmentsConfig.map((page) => {
+        return SegmentedPlugin.init().then((segmentedControl) => {
+            segmentedControl.setColor(BaseConfig.colors.primaryColor);
+            segmentedControl.setItems(page.items);
+            // eslint-disable-next-line
+            segmentedControl.on('itemSelect', (params) => navigationView.trigger(`segmented:${params.key}`));
+            layout.addTopView(segmentedControl, {
+                animated: false,
+                visible: false
             });
-        }
-    );
+            urlMap[page.url] = segmentedControl;
+        });
+    });
+
+    await Promise.all(segmentConfigPromises);
+    return new SegmentedController(layout, navigationView, urlMap);
 };
 
 SegmentedController.prototype.showSegmentsForUrl = function(url) {

--- a/app/app-controllers/segmentedController.js
+++ b/app/app-controllers/segmentedController.js
@@ -23,10 +23,7 @@ SegmentedController.init = function(layoutPromise, navigationViewPromise) {
                         segmentedControl.setColor(BaseConfig.colors.primaryColor);
                         segmentedControl.setItems(page.items);
                         // eslint-disable-next-line
-                        segmentedControl.on('itemSelect', (params) => {
-                            console.log('segmented Contoller caught an itemSelect event!!!');
-                            navigationView.trigger(`segmented:${params.key}`);
-                        });
+                        segmentedControl.on('itemSelect', (params) => navigationView.trigger(`segmented:${params.key}`));
                         layout.addTopView(segmentedControl, {
                             animated: false,
                             visible: false

--- a/app/app-controllers/segmentedController.js
+++ b/app/app-controllers/segmentedController.js
@@ -1,10 +1,9 @@
 import Promise from 'bluebird';
-import AnchoredLayoutPlugin from 'astro/plugins/anchoredLayoutPlugin';
 import SegmentedPlugin from 'astro/plugins/segmentedPlugin';
 import BaseConfig from '../app-config/baseConfig';
 import SegmentsConfig from '../app-config/segmentsConfig';
 
-var SegmentedController = function(layout, navigationView, urlMap) {
+const SegmentedController = function(layout, navigationView, urlMap) {
     this.parentLayout = layout;
     this.navigationView = navigationView;
     this.urlMap = urlMap;
@@ -13,18 +12,20 @@ var SegmentedController = function(layout, navigationView, urlMap) {
 };
 
 SegmentedController.init = function(layoutPromise, navigationViewPromise) {
-    var urlMap = {};
+    const urlMap = {};
     return Promise.join(
         layoutPromise,
         navigationViewPromise,
-        function(layout, navigationView) {
+        (layout, navigationView) => {
             return Promise.all(
-                SegmentsConfig.map(function(page, _) {
-                    return SegmentedPlugin.init().then(function(segmentedControl) {
+                SegmentsConfig.map((page) => {
+                    return SegmentedPlugin.init().then((segmentedControl) => {
                         segmentedControl.setColor(BaseConfig.colors.primaryColor);
                         segmentedControl.setItems(page.items);
-                        segmentedControl.on('itemSelect', function(params) {
-                            navigationView.trigger('segmented:' + params.key);
+                        // eslint-disable-next-line
+                        segmentedControl.on('itemSelect', (params) => {
+                            console.log('segmented Contoller caught an itemSelect event!!!');
+                            navigationView.trigger(`segmented:${params.key}`);
                         });
                         layout.addTopView(segmentedControl, {
                             animated: false,
@@ -33,7 +34,7 @@ SegmentedController.init = function(layoutPromise, navigationViewPromise) {
                         urlMap[page.url] = segmentedControl;
                     });
                 })
-            ).then(function() {
+            ).then(() => {
                 return new SegmentedController(layout, navigationView, urlMap);
             });
         }
@@ -41,25 +42,23 @@ SegmentedController.init = function(layoutPromise, navigationViewPromise) {
 };
 
 SegmentedController.prototype.showSegmentsForUrl = function(url) {
-    var self = this;
-    if (self.currentSegments) {
-        self.parentLayout.hideView(this.currentSegments);
+    if (this.currentSegments) {
+        this.parentLayout.hideView(this.currentSegments);
     }
-    var urlObject = new URL(url);
-    var segments = self._getSegmentsByUrl(url);
+    const segments = this._getSegmentsByUrl(url);
     if (segments) {
-        self.parentLayout.showView(segments, {animated: false});
-        self.currentSegments = segments;
+        this.parentLayout.showView(segments, {animated: false});
+        this.currentSegments = segments;
         // Must re-trigger the currently selected segment for
         // client-side js to run again
-        self.currentSegments.getSelectedItem().then(function(key) {
-            self.navigationView.trigger('segmented:' + key);
+        this.currentSegments.getSelectedItem().then((key) => {
+            this.navigationView.trigger(`segmented:${key}`);
         });
     }
 };
 
 SegmentedController.prototype._getSegmentsByUrl = function(url) {
-    var urlObject = new URL(url);
+    const urlObject = new URL(url);
     if (urlObject.pathname in this.urlMap) {
         return this.urlMap[urlObject.pathname];
     } else if (urlObject.pathname.slice(0, -1) in this.urlMap) {
@@ -70,13 +69,8 @@ SegmentedController.prototype._getSegmentsByUrl = function(url) {
 };
 
 SegmentedController.prototype._registerEvents = function() {
-    var self = this;
-    this.navigationView.on('back', function(params) {
-        self.showSegmentsForUrl(params.url);
-    });
-    this.navigationView.on('segmented:reload', function(params) {
-        self.showSegmentsForUrl(params.url);
-    });
+    this.navigationView.on('back', (params) => this.showSegmentsForUrl(params.url));
+    this.navigationView.on('segmented:reload', (params) => this.showSegmentsForUrl(params.url));
 };
 
-module.exports = SegmentedController;
+export default SegmentedController;

--- a/app/app-controllers/tabBarController.js
+++ b/app/app-controllers/tabBarController.js
@@ -45,32 +45,22 @@ const initRegularTabs = function(
     });
 };
 
-TabBarController.init = function(
-    layoutPromise,
-    cartEventHandlerPromise,
-    counterBadgeControllerPromise,
-    errorControllerPromise
+TabBarController.init = async function(
+    layout,
+    cartEventHandler,
+    counterBadgeController,
+    errorController
 ) {
-    const controllerPromise = Promise.join(
-        TabBarPlugin.init(),
-        layoutPromise,
-        (tabBar, layout) => {
-            return new TabBarController(tabBar, layout);
-        }
+    const tabBar = await TabBarPlugin.init();
+
+    const controller = new TabBarController(tabBar, layout);
+    return initRegularTabs(
+        controller,
+        TabConfig.tabItems,
+        cartEventHandler,
+        counterBadgeController,
+        errorController
     );
-
-    const constructTabItemsPromise = Promise.resolve(TabConfig.tabItems);
-
-    return Promise.join(
-        controllerPromise,
-        constructTabItemsPromise,
-        cartEventHandlerPromise,
-        counterBadgeControllerPromise,
-        errorControllerPromise,
-        initRegularTabs
-    ).then((controller) => {
-        return controller;
-    });
 };
 
 TabBarController.prototype.selectTab = function(tabId) {

--- a/app/app-controllers/tabBarController.js
+++ b/app/app-controllers/tabBarController.js
@@ -3,7 +3,7 @@ import TabBarPlugin from 'astro/plugins/tabBarPlugin';
 import TabConfig from '../app-config/tabConfig';
 import NavigationController from './navigationController';
 
-var TabBarController = function(tabBar, layout) {
+const TabBarController = function(tabBar, layout) {
     this.tabBar = tabBar;
     this.viewPlugin = layout;
     this.activeTabId = null;
@@ -18,7 +18,7 @@ var TabBarController = function(tabBar, layout) {
     this._bindEvents();
 };
 
-var initRegularTabs = function(
+const initRegularTabs = function(
     controller,
     tabItems,
     cartEventHandler,
@@ -26,20 +26,20 @@ var initRegularTabs = function(
     errorController
 ) {
     // Make sure all tabViews are set up
-    return Promise.all(tabItems.map(function(tab) {
+    return Promise.all(tabItems.map((tab) => {
         // Init a new NavigationController
-        var navigationControllerPromise = NavigationController.init(
+        const navigationControllerPromise = NavigationController.init(
             tab.id,
             tab.url,
             counterBadgeController,
             cartEventHandler,
             errorController
         );
-        return navigationControllerPromise.then(function(navigationController) {
+        return navigationControllerPromise.then((navigationController) => {
             controller._navigationControllers[tab.id] = navigationController;
             controller._tabViews[tab.id] = navigationController.viewPlugin;
         });
-    })).then(function() {
+    })).then(() => {
         controller.tabBar.setItems(tabItems);
         return controller;
     });
@@ -51,15 +51,15 @@ TabBarController.init = function(
     counterBadgeControllerPromise,
     errorControllerPromise
 ) {
-    var controllerPromise = Promise.join(
+    const controllerPromise = Promise.join(
         TabBarPlugin.init(),
         layoutPromise,
-        function(tabBar, layout) {
+        (tabBar, layout) => {
             return new TabBarController(tabBar, layout);
         }
     );
 
-    var constructTabItemsPromise = Promise.resolve(TabConfig.tabItems);
+    const constructTabItemsPromise = Promise.resolve(TabConfig.tabItems);
 
     return Promise.join(
         controllerPromise,
@@ -68,7 +68,7 @@ TabBarController.init = function(
         counterBadgeControllerPromise,
         errorControllerPromise,
         initRegularTabs
-    ).then(function(controller) {
+    ).then((controller) => {
         return controller;
     });
 };
@@ -87,20 +87,20 @@ TabBarController.prototype._selectTabHandler = function(tabId) {
         this.viewPlugin.setContentView(this._tabViews[tabId]);
         this.activeTabId = tabId;
 
-        var selectedTab = this.getActiveNavigationView();
+        const selectedTab = this.getActiveNavigationView();
         selectedTab.isActive = true;
 
         if (selectedTab.needsReload()) {
-            var selectedNavigationView = selectedTab.navigationView;
+            const selectedNavigationView = selectedTab.navigationView;
             Promise.join(
                 selectedNavigationView.canGoBack(),
                 selectedNavigationView.getTopPlugin(),
-                function(tabCanGoBack, topPlugin) {
+                (tabCanGoBack, topPlugin) => {
                     // In the case where a tab failed its initial navigation
                     // a reload is insufficient so instead, we navigate to
                     // the tab's root URL.
                     if (!tabCanGoBack && typeof topPlugin.navigate === 'function') {
-                        var tabItem = TabConfig.tabItems[tabId - 1];
+                        const tabItem = TabConfig.tabItems[tabId - 1];
                         topPlugin.navigate(tabItem.url);
                     } else {
                         topPlugin.reload();
@@ -119,12 +119,8 @@ TabBarController.prototype.getActiveNavigationView = function() {
 };
 
 TabBarController.prototype._bindEvents = function() {
-    var self = this;
-
     // Select Tab
-    this.tabBar.on('itemSelect', function(data) {
-        self._selectTabHandler(data.id);
-    });
+    this.tabBar.on('itemSelect', (data) => this._selectTabHandler(data.id));
 };
 
 TabBarController.prototype.navigateActiveItem = function(url) {
@@ -133,14 +129,14 @@ TabBarController.prototype.navigateActiveItem = function(url) {
 
 TabBarController.prototype.backActiveItem = function() {
     if (this.canGoBack()) {
-        var activeTab = this.getActiveNavigationView();
+        const activeTab = this.getActiveNavigationView();
         activeTab.back();
     }
 };
 
 TabBarController.prototype.canGoBack = function() {
-    var activeTab = this.getActiveNavigationView();
+    const activeTab = this.getActiveNavigationView();
     return activeTab.canGoBack();
 };
 
-module.exports = TabBarController;
+export default TabBarController;

--- a/app/app-controllers/welcome-screen/welcomeController.js
+++ b/app/app-controllers/welcome-screen/welcomeController.js
@@ -8,7 +8,7 @@ import AppRpc from '../../global/app-rpc';
 import WelcomeConfig from '../../app-config/welcomeConfig';
 import WelcomeHeaderController from './welcomeHeaderController';
 
-var WelcomeController = function(navigationView, layout, headerController) {
+const WelcomeController = function(navigationView, layout, headerController) {
     this.viewPlugin = layout;
 
     this.navigationView = navigationView;
@@ -27,16 +27,16 @@ WelcomeController.init = function() {
 
     // With a header bar, we use a navigationPlugin to handle
     // navigation and stacking animations.
-    var initWithHeader = function() {
+    const initWithHeader = function() {
         return Promise.join(
             NavigationPlugin.init(),
             AnchoredLayoutPlugin.init(),
             WelcomeHeaderController.init(),
-        function(navigationView, layout, headerController) {
-            var loader = navigationView.getLoader();
+        (navigationView, layout, headerController) => {
+            const loader = navigationView.getLoader();
             loader.setColor(BaseConfig.loaderColor);
             navigationView.setHeaderBar(headerController.viewPlugin);
-            headerController.registerBackEventHandler(function() {
+            headerController.registerBackEventHandler(() => {
                 navigationView.back();
             });
 
@@ -47,7 +47,7 @@ WelcomeController.init = function() {
             layout.addTopView(headerController.viewPlugin);
             layout.setContentView(navigationView);
 
-            var welcomeController = new WelcomeController(navigationView, layout, headerController);
+            const welcomeController = new WelcomeController(navigationView, layout, headerController);
             welcomeController.navigate(WelcomeConfig.url);
             return welcomeController;
         });
@@ -55,29 +55,29 @@ WelcomeController.init = function() {
 
     // To navigate without stacking, we use a WebViewPlugin to
     // handle navigation -- desired behaviour w/o header
-    var initWithoutHeader = function() {
+    const initWithoutHeader = function() {
         return Promise.join(
             WebViewPlugin.init(),
             AnchoredLayoutPlugin.init(),
-        function(webView, layout) {
+        (webView, layout) => {
             // Disable webview loader when first loading welcome page
             webView.disableLoader();
 
-            var loader = webView.getLoader();
+            const loader = webView.getLoader();
             loader.setColor(BaseConfig.loaderColor);
             layout.setContentView(webView);
 
             // Remove this line to enable scrolling on welcome screen
             webView.disableScrolling();
 
-            var welcomeController = new WelcomeController(webView, layout);
+            const welcomeController = new WelcomeController(webView, layout);
             welcomeController.navigate(WelcomeConfig.url);
 
             return welcomeController;
         });
     };
 
-    Astro.registerRpcMethod(AppRpc.names.welcomeHasHeader, [], function(res) {
+    Astro.registerRpcMethod(AppRpc.names.welcomeHasHeader, [], (res) => {
         res.send(null, WelcomeConfig.showHeader);
     });
 
@@ -100,7 +100,7 @@ WelcomeController.prototype.navigate = function(url) {
         return;
     }
 
-    var self = this;
+    const self = this;
     // Without a header controller, we do not need to generate header
     // content for the navigation. Instead, we allow the webView to
     // simply navigate.
@@ -109,8 +109,8 @@ WelcomeController.prototype.navigate = function(url) {
         return;
     }
 
-    var navigationHandler = function(params) {
-        var url = params.url;
+    const navigationHandler = function(params) {
+        const url = params.url;
         // We're expected to navigate the web view if we're called with a
         // url and the web view isn't in the process of redirecting (i.e.
         // `params.isCurrentlyLoading` is not set).
@@ -119,9 +119,9 @@ WelcomeController.prototype.navigate = function(url) {
         }
     };
 
-    self.headerController.generateContent().then(function(headerContent) {
-        var webViewPluginOptions = {
-            navigationHandler: navigationHandler,
+    self.headerController.generateContent().then((headerContent) => {
+        const webViewPluginOptions = {
+            navigationHandler,
             enableLoader: []
         };
         return self.navigationView.navigateToUrl(url, headerContent, webViewPluginOptions);
@@ -136,4 +136,4 @@ WelcomeController.prototype.canGoBack = function() {
     return this.navigationView.canGoBack();
 };
 
-module.exports = WelcomeController;
+export default WelcomeController;

--- a/app/app-controllers/welcome-screen/welcomeHeaderController.js
+++ b/app/app-controllers/welcome-screen/welcomeHeaderController.js
@@ -6,14 +6,13 @@ const WelcomeHeaderController = function(headerBar) {
     this.viewPlugin = headerBar;
 };
 
-WelcomeHeaderController.init = function() {
-    return HeaderBarPlugin.init().then((headerBar) => {
-        headerBar.setTextColor(WelcomeConfig.colors.textColor);
-        headerBar.setBackgroundColor(WelcomeConfig.colors.backgroundColor);
-        headerBar.hideBackButtonText();
+WelcomeHeaderController.init = async function() {
+    const headerBar = await HeaderBarPlugin.init();
+    headerBar.setTextColor(WelcomeConfig.colors.textColor);
+    headerBar.setBackgroundColor(WelcomeConfig.colors.backgroundColor);
+    headerBar.hideBackButtonText();
 
-        return new WelcomeHeaderController(headerBar);
-    });
+    return new WelcomeHeaderController(headerBar);
 };
 
 WelcomeHeaderController.prototype.generateContent = function() {

--- a/app/app-controllers/welcome-screen/welcomeHeaderController.js
+++ b/app/app-controllers/welcome-screen/welcomeHeaderController.js
@@ -2,12 +2,12 @@ import Promise from 'bluebird';
 import HeaderBarPlugin from 'astro/plugins/headerBarPlugin';
 import WelcomeConfig from '../../app-config/welcomeConfig';
 
-var WelcomeHeaderController = function(headerBar) {
+const WelcomeHeaderController = function(headerBar) {
     this.viewPlugin = headerBar;
 };
 
 WelcomeHeaderController.init = function() {
-    return HeaderBarPlugin.init().then(function(headerBar) {
+    return HeaderBarPlugin.init().then((headerBar) => {
         headerBar.setTextColor(WelcomeConfig.colors.textColor);
         headerBar.setBackgroundColor(WelcomeConfig.colors.backgroundColor);
         headerBar.hideBackButtonText();
@@ -17,7 +17,7 @@ WelcomeHeaderController.init = function() {
 };
 
 WelcomeHeaderController.prototype.generateContent = function() {
-    var headerContent = {
+    const headerContent = {
         header: {
             centerIcon: WelcomeConfig.headerContent,
             rightIcon: WelcomeConfig.closeIcon
@@ -32,7 +32,7 @@ WelcomeHeaderController.prototype.registerCloseEventHandler = function(callback)
         return;
     }
 
-    this.viewPlugin.on('click:' + WelcomeConfig.closeIcon.id, callback);
+    this.viewPlugin.on(`click:${WelcomeConfig.closeIcon.id}`, callback);
 };
 
 WelcomeHeaderController.prototype.registerBackEventHandler = function(callback) {
@@ -43,4 +43,4 @@ WelcomeHeaderController.prototype.registerBackEventHandler = function(callback) 
     this.viewPlugin.on('click:back', callback);
 };
 
-module.exports = WelcomeHeaderController;
+export default WelcomeHeaderController;

--- a/app/app-controllers/welcome-screen/welcomeModalController.js
+++ b/app/app-controllers/welcome-screen/welcomeModalController.js
@@ -14,101 +14,105 @@ const WelcomeModalController = function(modalView, welcomeController, secureStor
     this.welcomeController = welcomeController;
 };
 
-WelcomeModalController.init = function(errorController) {
-    return Promise.join(
+WelcomeModalController.init = async function(errorController) {
+    const [
+        modalView,
+        welcomeController,
+        secureStore
+    ] = await Promise.all([
         ModalViewPlugin.init(),
         WelcomeController.init(),
-        SecureStorePlugin.init(),
-    (modalView, welcomeController, secureStore) => {
-        modalView.setContentView(welcomeController.viewPlugin);
+        SecureStorePlugin.init()
+    ]);
 
-        // This registers a close handler on the header bar to dismiss
-        // the modal. Without a header bar, the developer is responsible
-        // for implementing a way to dismiss the modal.
-        const welcomeModalController = new WelcomeModalController(modalView, welcomeController, secureStore);
-        welcomeController.registerCloseEventHandler(() => {
-            welcomeModalController.hide();
-        });
+    modalView.setContentView(welcomeController.viewPlugin);
 
-        // Welcome modal RPCs
-        Astro.registerRpcMethod(AppRpc.names.welcomeShow, [], () => {
-            welcomeModalController.show({forced: true});
-        });
-
-        Astro.registerRpcMethod(AppRpc.names.welcomeHide, [], () => {
-            welcomeModalController.hide();
-        });
-
-        // If you have implemented your own custom native welcome plugin
-        // you may also need to modify the following error modal handlers
-        const navigator = welcomeController.navigationView;
-        const backHandler = function() {
-            // We only navigate back if our navigator is a navigationView.
-            // webViewPlugins do not complete navigation if they fail.
-            if (typeof navigator.getEventPluginPromise === 'function') {
-                navigator.back();
-            }
-        };
-
-        const retryHandler = function(params) {
-            if (!params.url) {
-                return;
-            }
-            if (typeof navigator.getEventPluginPromise === 'function') {
-                const navigate = function(eventPlugin) {
-                    eventPlugin.navigate(params.url);
-                };
-                navigator.getEventPluginPromise(params).then(navigate);
-            } else {
-                navigator.navigate(params.url);
-            }
-        };
-
-        // Welcome modal should never dismiss unless the user has
-        // completed the welcome flow.
-        const canGoBack = function() {
-            return Promise.resolve(false);
-        };
-
-        errorController.bindToNavigator({
-            navigator,
-            backHandler,
-            retryHandler,
-            isActiveItem: welcomeModalController.isActiveItem,
-            canGoBack
-        });
-        return welcomeModalController;
+    // This registers a close handler on the header bar to dismiss
+    // the modal. Without a header bar, the developer is responsible
+    // for implementing a way to dismiss the modal.
+    const welcomeModalController = new WelcomeModalController(modalView, welcomeController, secureStore);
+    welcomeController.registerCloseEventHandler(() => {
+        welcomeModalController.hide();
     });
+
+    // Welcome modal RPCs
+    Astro.registerRpcMethod(AppRpc.names.welcomeShow, [], () => {
+        welcomeModalController.show({forced: true});
+    });
+
+    Astro.registerRpcMethod(AppRpc.names.welcomeHide, [], () => {
+        welcomeModalController.hide();
+    });
+
+    // If you have implemented your own custom native welcome plugin
+    // you may also need to modify the following error modal handlers
+    const navigator = welcomeController.navigationView;
+    const backHandler = function() {
+        // We only navigate back if our navigator is a navigationView.
+        // webViewPlugins do not complete navigation if they fail.
+        if (typeof navigator.getEventPluginPromise === 'function') {
+            navigator.back();
+        }
+    };
+
+    const retryHandler = function(params) {
+        if (!params.url) {
+            return;
+        }
+        if (typeof navigator.getEventPluginPromise === 'function') {
+            const navigate = function(eventPlugin) {
+                eventPlugin.navigate(params.url);
+            };
+            navigator.getEventPluginPromise(params).then(navigate);
+        } else {
+            navigator.navigate(params.url);
+        }
+    };
+
+    // Welcome modal should never dismiss unless the user has
+    // completed the welcome flow.
+    const canGoBack = function() {
+        return Promise.resolve(false);
+    };
+
+    errorController.bindToNavigator({
+        navigator,
+        backHandler,
+        retryHandler,
+        isActiveItem: welcomeModalController.isActiveItem,
+        canGoBack
+    });
+    return welcomeModalController;
 };
 
-WelcomeModalController.prototype.show = function(params) {
+WelcomeModalController.prototype.show = async function(params) {
     const self = this;
     params = Astro.Utils.extend({forced: false}, params);
 
-    return Promise.join(
+    const [
+        appInfo,
+        previousInstallationID
+    ] = await Promise.all([
         Application.getAppInformation(),
-        self._secureStore.get('installationID'),
-        (appInfo, previousInstallationID) => {
-            // Welcome modal should be triggered when installationID changes
-            // NOTE: appInfo.installationID appears to be different on each app run
-            // on the iOS Simulator, but on real devices they will persist.
-            return new Promise((resolve, reject) => {
-                if (appInfo.installationID !== previousInstallationID || params.forced) {
-                    self.isShowing = true;
-                    self.modalView.show({animated: true});
+        self._secureStore.get('installationID')
+    ]);
 
-                    // Promise will be resolved when welcome modal is dismissed
-                    AppEvents.on(AppEvents.names.welcomeHidden, () => {
-                        self._secureStore.set('installationID', appInfo.installationID);
-                        resolve();
-                    });
-                    AppEvents.trigger(AppEvents.names.welcomeShown);
-                } else {
-                    reject();
-                }
-            });
-        }
-    );
+    // Welcome modal should be triggered when installationID changes
+    // NOTE: appInfo.installationID appears to be different on each app run
+    // on the iOS Simulator, but on real devices they will persist.
+    if (appInfo.installationID !== previousInstallationID || params.forced) {
+        self.isShowing = true;
+        self.modalView.show({animated: true});
+
+        // Promise will be resolved when welcome modal is dismissed
+        AppEvents.on(AppEvents.names.welcomeHidden, () => {
+            self._secureStore.set('installationID', appInfo.installationID);
+            return;
+        });
+        AppEvents.trigger(AppEvents.names.welcomeShown);
+    } else {
+        throw new Error();
+    }
 };
 
 WelcomeModalController.prototype.hide = function() {

--- a/app/app-controllers/welcome-screen/welcomeModalController.js
+++ b/app/app-controllers/welcome-screen/welcomeModalController.js
@@ -14,13 +14,12 @@ const WelcomeModalController = function(modalView, welcomeController, secureStor
     this.welcomeController = welcomeController;
 };
 
-WelcomeModalController.init = function(errorControllerPromise) {
+WelcomeModalController.init = function(errorController) {
     return Promise.join(
         ModalViewPlugin.init(),
         WelcomeController.init(),
         SecureStorePlugin.init(),
-        errorControllerPromise,
-    (modalView, welcomeController, secureStore, errorController) => {
+    (modalView, welcomeController, secureStore) => {
         modalView.setContentView(welcomeController.viewPlugin);
 
         // This registers a close handler on the header bar to dismiss

--- a/app/app-plugins/doubleIconsPlugin.js
+++ b/app/app-plugins/doubleIconsPlugin.js
@@ -4,7 +4,7 @@ import PluginManager from 'astro/plugin-manager';
 /**
 * Constructor
 */
-var DoubleIconsPlugin = function() {};
+const DoubleIconsPlugin = function() {};
 
 /**
 * Defines the plugin name, which is necessary for
@@ -19,4 +19,4 @@ DoubleIconsPlugin.init = function(callback) {
 DoubleIconsPlugin.prototype.setLeftIcon = Astro.nativeRpcMethod('setLeftIcon', ['address']);
 DoubleIconsPlugin.prototype.setRightIcon = Astro.nativeRpcMethod('setRightIcon', ['address']);
 
-module.exports = DoubleIconsPlugin;
+export default DoubleIconsPlugin;

--- a/app/app.js
+++ b/app/app.js
@@ -1,4 +1,4 @@
-/*global AstroNative*/
+/* global AstroNative */
 window.AstroMessages = []; // For debugging messages
 
 // Astro
@@ -24,31 +24,32 @@ import ErrorController from './app-controllers/error-screen/errorController';
 import WelcomeModalController from './app-controllers/welcome-screen/welcomeModalController';
 
 window.run = function() {
-    var deepLinkingServices = null;
-    var errorControllerPromise = ErrorController.init();
-    var cartModalControllerPromise = CartModalController.init(errorControllerPromise);
-    var cartEventHandlerPromise = cartModalControllerPromise.then(
-        function(cartModalController) {
+    // eslint-disable-next-line
+    let deepLinkingServices = null;
+    const errorControllerPromise = ErrorController.init();
+    const cartModalControllerPromise = CartModalController.init(errorControllerPromise);
+    const cartEventHandlerPromise = cartModalControllerPromise.then(
+        (cartModalController) => {
             return function() {
                 cartModalController.show();
             };
         });
 
-    var counterBadgeControllerPromise = CounterBadgeController.init(
+    const counterBadgeControllerPromise = CounterBadgeController.init(
         HeaderConfig.cartHeaderContent.imageUrl,
         HeaderConfig.cartHeaderContent.id
-    ).then(function(counterBadgeController) {
+    ).then((counterBadgeController) => {
         counterBadgeController.updateCounterValue(3);
         return counterBadgeController;
     });
 
     // Android hardware back
-    var setupHardwareBackButton = function(alternativeBackFunction) {
-        Application.on('backButtonPressed', function() {
+    const setupHardwareBackButton = function(alternativeBackFunction) {
+        Application.on('backButtonPressed', () => {
             Promise.join(
                 cartModalControllerPromise,
                 errorControllerPromise,
-            function(cartModalController, errorController) {
+            (cartModalController, errorController) => {
                 if (cartModalController.isShowing) {
                     cartModalController.hide();
                 } else if (errorController.isShowing) {
@@ -60,19 +61,19 @@ window.run = function() {
         });
     };
 
-    var createTabBarLayout = function() {
-        var layoutPromise = AnchoredLayoutPlugin.init();
-        var tabBarControllerPromise = TabBarController.init(
+    const createTabBarLayout = function() {
+        const layoutPromise = AnchoredLayoutPlugin.init();
+        const tabBarControllerPromise = TabBarController.init(
                 layoutPromise,
                 cartEventHandlerPromise,
                 counterBadgeControllerPromise,
                 errorControllerPromise
             );
 
-        var layoutSetupPromise = Promise.join(
+        const layoutSetupPromise = Promise.join(
             layoutPromise,
             tabBarControllerPromise,
-        function(layout, tabBarController) {
+        (layout, tabBarController) => {
             layout.addBottomView(tabBarController.tabBar);
 
             return Application.setMainViewPlugin(layout);
@@ -85,22 +86,22 @@ window.run = function() {
         return Promise.join(
             tabBarControllerPromise,
             layoutSetupPromise,
-        function(tabBarController) {
+        (tabBarController) => {
             setupHardwareBackButton(tabBarController.backActiveItem.bind(tabBarController));
             return tabBarController;
         });
     };
 
-    var createDrawerLayout = function() {
+    const createDrawerLayout = function() {
         return DrawerController.init(
             counterBadgeControllerPromise,
             cartEventHandlerPromise,
             errorControllerPromise
-        ).then(function(drawerController) {
+        ).then((drawerController) => {
             Application.setMainViewPlugin(drawerController.drawer);
             setupHardwareBackButton(drawerController.backActiveItem.bind(drawerController));
 
-            Astro.registerRpcMethod(AppRpc.names.navigateToNewRootView, ['url', 'title'], function(res, url, title) {
+            Astro.registerRpcMethod(AppRpc.names.navigateToNewRootView, ['url', 'title'], (res, url, title) => {
                 drawerController.navigateToNewRootView(url, title);
                 res.send(null, 'success');
             });
@@ -108,29 +109,30 @@ window.run = function() {
         });
     };
 
-    var createLayout = function() {
+    const createLayout = function() {
         return BaseConfig.useTabLayout
             ? createTabBarLayout()
             : createDrawerLayout();
     };
 
-    var initMainLayout = function() {
-        return createLayout().then(function(layoutController) {
+    const initMainLayout = function() {
+        return createLayout().then((layoutController) => {
             Application.dismissLaunchImage();
 
             // Deep linking services will enable deep linking on startup
             // and while running it will open the deep link in the current
             // active tab
+            // eslint-disable-no-unused-vars
             deepLinkingServices = new DeepLinkingServices(layoutController);
         });
     };
 
-    var runApp = function(previewedUrl) {
+    const runApp = function() {
         // TODO: [HYB-884] As a Scaffold developer,
         // I would like for the baseURL to be set to the previewed URL
 
         WelcomeModalController.init(errorControllerPromise)
-            .then(function(welcomeModalController) {
+            .then((welcomeModalController) => {
                 // The welcome modal can be configured to show only once
                 // (on first launch) by setting `{forced: false}` as the
                 // parameter for welcomeModalController.show()
@@ -140,39 +142,24 @@ window.run = function() {
             });
     };
 
-    var runAppPreview = function() {
+    const runAppPreview = function() {
         MobifyPreviewPlugin.init()
-            .then(function(previewPlugin) {
+            .then((previewPlugin) => {
                 previewPlugin
                     .preview(BaseConfig.baseURL, BaseConfig.previewBundle)
                     .then(runApp);
             });
     };
 
-    PreviewController.init().then(function(previewController) {
-        Application.on('previewToggled', function() {
-            previewController.presentPreviewAlert();
-        });
-
-        previewController.isPreviewEnabled().then(function(enabled) {
-            // Configure the previewEnabled flag located in baseConfig.js
-            // to enable/disable app preview
-            if (enabled && BaseConfig.previewEnabled) {
-                runAppPreview();
-            } else {
-                runApp();
-            }
-        });
-    });
-
-    var initalizeAppWithAstroPreview = function() {
-        PreviewController.init().then(function(previewController) {
-            Application.on('previewToggled', function() {
+    const initalizeAppWithAstroPreview = function() {
+        PreviewController.init().then((previewController) => {
+            Application.on('previewToggled', () => {
                 previewController.presentPreviewAlert();
             });
 
             return previewController.isPreviewEnabled();
-        }).then(function(previewEnabled) {
+        })
+        .then((previewEnabled) => {
             if (previewEnabled) {
                 runAppPreview();
             } else {
@@ -188,4 +175,4 @@ window.run = function() {
     }
 };
 // Comment out next line for JS debugging
-window.run();
+// window.run();

--- a/app/global/app-events.js
+++ b/app/global/app-events.js
@@ -1,7 +1,7 @@
 import Astro from 'astro/astro-full';
 import BackboneEvents from 'vendor/backbone-events';
 
-var AppEvents = Astro.Utils.extend({}, BackboneEvents);
+const AppEvents = Astro.Utils.extend({}, BackboneEvents);
 
 // Dictionary of events raised by the application
 AppEvents.names = {
@@ -18,4 +18,4 @@ AppEvents.names = {
     welcomeHidden: 'welcome:hidden'
 };
 
-module.exports = AppEvents;
+export default AppEvents;

--- a/app/global/app-rpc.js
+++ b/app/global/app-rpc.js
@@ -1,6 +1,6 @@
 import Astro from 'astro/astro-full';
 
-var AppRpc = {};
+const AppRpc = {};
 
 AppRpc.names = {
     cartShow: 'cartShow',
@@ -22,4 +22,4 @@ AppRpc.welcomeHide = Astro.jsRpcMethod(AppRpc.names.welcomeHide, []);
 AppRpc.welcomeHasHeader = Astro.jsRpcMethod(AppRpc.names.welcomeHasHeader, []);
 AppRpc.navigateToNewRootView = Astro.jsRpcMethod(AppRpc.names.navigateToNewRootView, ['url', 'title']);
 
-module.exports = AppRpc;
+export default AppRpc;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "mobify/astro#develop",
+    "astro-sdk": "mobify/astro#tests-es6",
     "bluebird": "~2.9.24",
     "grunt-requirejs": "^0.4.2",
     "jquery": "^2.2.2",
@@ -11,8 +11,16 @@
     "webpack": "^2.1.0-beta.27"
   },
   "devDependencies": {
+    "babel-core": "^6.18.2",
+    "babel-eslint": "^7.1.1",
+    "babel-loader": "^6.2.8",
+    "babel-plugin-syntax-async-functions": "^6.13.0",
+    "babel-plugin-transform-async-to-module-method": "^6.16.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
+    "babel-preset-es2015": "^6.18.0",
     "eslint": "^3.10.2",
     "eslint-loader": "^1.6.1",
+    "eslint-plugin-import": "^2.2.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^1.1.0",
     "mobify-code-style": "^2.2.1",
@@ -29,7 +37,7 @@
     "deps": "./scripts/build-dependencies.sh ./app",
     "test": "./scripts/ios-appium.sh",
     "build": "webpack --config webpack.app.config.js",
-    "build-analyze": "NODE_ENV=Analyze npm run build"
+    "build-analyze": "ASTRO_ANALYZE=true npm run build"
   },
   "license": "SEE LICENSE IN LICENSE"
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "mobify/astro#tests-es6",
+    "astro-sdk": "mobify/astro#develop",
     "babel-runtime": "^6.18.0",
     "bluebird": "~2.9.24",
     "grunt-requirejs": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Mobify",
   "dependencies": {
     "astro-sdk": "mobify/astro#tests-es6",
+    "babel-runtime": "^6.18.0",
     "bluebird": "~2.9.24",
     "grunt-requirejs": "^0.4.2",
     "jquery": "^2.2.2",

--- a/scripts/build-dependencies.sh
+++ b/scripts/build-dependencies.sh
@@ -56,7 +56,7 @@ pushd $MYPATH/node_modules/astro-sdk
     echo "Installing dependencies for astro-sdk"
     npm install --no-progress --no-spin $EXTRA_NPM_ARGS
     echo "Building astro-client.js"
-    npm run pack:astro_client
+    npm run build:astro_client
 popd
 
 echo "Copying astro-client.js into app bundle"

--- a/webpack.app.config.js
+++ b/webpack.app.config.js
@@ -1,13 +1,15 @@
+/* eslint-disable */
+
 var webpack = require('webpack');
 var path = require('path');
 var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 var rootDir = process.cwd();
 var entry = path.resolve(rootDir, 'app/app.js');
-var outDir = path.resolve(rootDir, 'build');
+var outDir = path.resolve(rootDir, 'app/build');
 
 var isProd = process.env.NODE_ENV === 'production';
-var analyzeBundle = process.env.NODE_ENV === 'Analyze';
+var analyzeBundle = process.env.ASTRO_ANALYZE === 'true';
 
 var config = {
     entry: entry,
@@ -28,7 +30,8 @@ var config = {
         new webpack.LoaderOptionsPlugin({
             options: {
                 eslint: {
-                    configFile: path.resolve(rootDir, '.eslintrc.yml')
+                    configFile: path.resolve(__dirname, '.eslintrc.yml'),
+                    formatter: require('eslint/lib/formatters/unix')
                 }
             }
         })
@@ -39,6 +42,13 @@ var config = {
             enforce: 'pre',
             use: ['eslint-loader'],
             exclude: /node_modules/
+        }, {
+            test: /\.js$/,
+            use: ['babel-loader'],
+            include: [
+                path.resolve(rootDir, 'node_modules/astro-sdk/js'),
+                path.resolve(rootDir, 'app')
+            ]
         }]
     }
 };
@@ -48,7 +58,11 @@ if (isProd) {
         new webpack.optimize.UglifyJsPlugin(),
         new webpack.optimize.OccurrenceOrderPlugin()
     ]);
-} else if (analyzeBundle) {
+} else {
+    config.devtool = 'inline-source-maps';
+}
+
+if (analyzeBundle) {
     config.plugins = config.plugins.concat([
         new BundleAnalyzerPlugin({
             analyzerMode: 'static',

--- a/webpack.app.config.js
+++ b/webpack.app.config.js
@@ -20,7 +20,8 @@ var config = {
     resolve: {
         alias: {
             astro: path.resolve(rootDir, 'node_modules/astro-sdk/js/src/'),
-            vendor: path.resolve(rootDir, 'node_modules/astro-sdk/js/vendor/')
+            vendor: path.resolve(rootDir, 'node_modules/astro-sdk/js/vendor/'),
+            bluebird: path.resolve(rootDir, 'node_modules/astro-sdk/node_modules/bluebird')
         }
     },
     plugins: [


### PR DESCRIPTION
This PR upgrades the scaffold to ES6 syntax and replaces promise `.then`'s with async and await.

JIRA: **https://mobify.atlassian.net/browse/HYB-912**
Linked PRs: 
- https://github.com/mobify/astro/pull/719

## Changes
- Add `babel-loader` the Webpack build
- Upgrade to latest JS syntax
- Remove promises with async/await

## How to test-drive this PR
- Scaffold all works as expected on iOS and Android with no errors in the console

## TODOS:
- [x] Point back to `astro#develop`
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)

