### PR TITLE
Make scaffold work with refactored android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [Android] Update to Gradle 2.14, update project to Android Studio 2.2
 - [Android] Scaffold app only support handsets
 - [iOS] Enable install of preview-enabled and app store versions of generated apps
+- [Android] Update custom plugins to match new plugin constructors. Remove reference to CommonApplication as it no longer exists.
 
 ## v0.17.6
 - Add multiple build configurations to support enabling/disabling Mobify Preview

--- a/android/scaffold/src/main/AndroidManifest.xml
+++ b/android/scaffold/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     package="com.mobify.astro.scaffold" >
 
     <application
-        android:name="com.mobify.astro.CommonApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name">

--- a/android/scaffold/src/main/java/com/mobify/astro/scaffold/MainActivity.java
+++ b/android/scaffold/src/main/java/com/mobify/astro/scaffold/MainActivity.java
@@ -13,6 +13,6 @@ public class MainActivity extends AstroActivity {
         super.onCreate(savedInstanceState);
 
         // Create the initial worker.
-        worker = new AstroWorker(this, pluginManager);
+        worker = new AstroWorker(this, pluginManager, eventManager, messageSender);
     }
 }

--- a/android/scaffold/src/main/java/com/mobify/astro/scaffold/plugins/DoubleIconsPlugin.java
+++ b/android/scaffold/src/main/java/com/mobify/astro/scaffold/plugins/DoubleIconsPlugin.java
@@ -5,12 +5,15 @@ import com.mobify.astro.AstroPlugin;
 import com.mobify.astro.PluginResolver;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
+import com.mobify.astro.messaging.EventRegistrar;
+import com.mobify.astro.messaging.MessageSender;
 import com.mobify.astro.messaging.annotations.RpcMethod;
 import com.mobify.astro.plugins.headerbarplugin.HeaderContentItem;
 import com.mobify.astro.scaffold.R;
@@ -64,8 +67,9 @@ public class DoubleIconsPlugin extends AstroPlugin {
         }
     }
 
-    public DoubleIconsPlugin(AstroActivity activity, PluginResolver pluginResolver) {
-        super(activity, pluginResolver);
+    public DoubleIconsPlugin(@NonNull AstroActivity activity, @NonNull PluginResolver pluginResolver,
+                             @NonNull EventRegistrar eventRegistrar, @NonNull MessageSender messageSender) {
+        super(activity, pluginResolver, eventRegistrar, messageSender);
 
         final int minItemSize = activity.getResources().getDimensionPixelSize(R.dimen.header_bar_item_min_size);
 


### PR DESCRIPTION
JIRA: **https://mobify.atlassian.net/browse/HYB-915**
Linked PRs: **https://github.com/mobify/astro/pull/718** (merged)

## Changes
- The most recent android refactor requires all `AstroPlugins` to take a couple more parameters and pass them through to their super (`EventRegistrar` and `MessageSender`).
- The refactor also got rid of `CommonApplication` so this must be removed from the `AndroidManifest` otherwise the app will crash

## How to test-drive this PR
- `npm run deps` and test the Android scaffold

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [ ] ~~Run the generator to make sure it still functions correctly.~~ -- confident this didn't break the generator
- [ ] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)

