### PR TITLE
Settings Store Used in Welcome Modal and update to mobify-progressive-app-sdk npm module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## To be released
+- Point npm pacakge to new astro location: mobfiy-progressive-app-sdk
+- Welcome modal uses SettingsStore instead of SecureStore
 - ES6 and Async/Await Compatible with Babel
 - [Android] Update to Gradle 2.14, update project to Android Studio 2.2
 - [Android] Scaffold app only support handsets

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd astro
 npm link
 ```
 
-Then navigate back to your project root directory and run: `npm link astro-sdk`
+Then navigate back to your project root directory and run: `npm link mobify-progressive-app-sdk`
 to use your locally developed version of Astro.
 
 # Switching between Debug and Release mode

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -10,8 +10,8 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/scaffold" />
-            <option value="$PROJECT_DIR$/../node_modules/astro-sdk/android" />
-            <option value="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient" />
+            <option value="$PROJECT_DIR$/../node_modules/mobify-progressive-app-sdk/android" />
+            <option value="$PROJECT_DIR$/../node_modules/mobify-progressive-app-sdk/node_modules/mobify-push-android-client/pushclient" />
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />

--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/.idea/modules.xml
+++ b/android/.idea/modules.xml
@@ -3,7 +3,9 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/android.iml" filepath="$PROJECT_DIR$/android.iml" />
+      <module fileurl="file://$PROJECT_DIR$/../node_modules/mobify-progressive-app-sdk/android/astro.iml" filepath="$PROJECT_DIR$/../node_modules/mobify-progressive-app-sdk/android/astro.iml" />
       <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" />
+      <module fileurl="file://$PROJECT_DIR$/../node_modules/mobify-progressive-app-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" filepath="$PROJECT_DIR$/../node_modules/mobify-progressive-app-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" />
       <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" />
       <module fileurl="file://$PROJECT_DIR$/scaffold/scaffold.iml" filepath="$PROJECT_DIR$/scaffold/scaffold.iml" />
     </modules>

--- a/android/.idea/modules.xml
+++ b/android/.idea/modules.xml
@@ -4,9 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/android.iml" filepath="$PROJECT_DIR$/android.iml" />
       <module fileurl="file://$PROJECT_DIR$/../node_modules/mobify-progressive-app-sdk/android/astro.iml" filepath="$PROJECT_DIR$/../node_modules/mobify-progressive-app-sdk/android/astro.iml" />
-      <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/android/astro.iml" />
       <module fileurl="file://$PROJECT_DIR$/../node_modules/mobify-progressive-app-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" filepath="$PROJECT_DIR$/../node_modules/mobify-progressive-app-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" />
-      <module fileurl="file://$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" filepath="$PROJECT_DIR$/../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient/pushclient.iml" />
       <module fileurl="file://$PROJECT_DIR$/scaffold/scaffold.iml" filepath="$PROJECT_DIR$/scaffold/scaffold.iml" />
     </modules>
   </component>

--- a/android/scaffold/scaffold.iml
+++ b/android/scaffold/scaffold.iml
@@ -8,12 +8,12 @@
     </facet>
     <facet type="android" name="Android">
       <configuration>
-        <option name="SELECTED_BUILD_VARIANT" value="debug" />
+        <option name="SELECTED_BUILD_VARIANT" value="previewDisabledDebug" />
         <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
-        <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
-        <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
+        <option name="ASSEMBLE_TASK_NAME" value="assemblePreviewDisabledDebug" />
+        <option name="COMPILE_JAVA_TASK_NAME" value="compilePreviewDisabledDebugSources" />
         <afterSyncTasks>
-          <task>generateDebugSources</task>
+          <task>generatePreviewDisabledDebugSources</task>
         </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
@@ -24,24 +24,64 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
-    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
+    <output url="file://$MODULE_DIR$/build/intermediates/classes/previewDisabled/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/previewDisabled/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/previewDisabled/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/previewDisabled/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/previewDisabled/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/previewDisabled/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/previewDisabled/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/previewDisabled/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/previewDisabled/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/jni" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/previewDisabled/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/previewDisabled/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/jni" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabled/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabled/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabled/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabled/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabled/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabled/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabled/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabled/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestPreviewDisabled/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestPreviewDisabled/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestPreviewDisabled/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestPreviewDisabled/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestPreviewDisabled/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestPreviewDisabled/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestPreviewDisabled/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestPreviewDisabled/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
@@ -66,14 +106,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -82,9 +114,16 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/animated-vector-drawable/23.3.0/jars" />
@@ -93,7 +132,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-vector-drawable/23.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
@@ -118,13 +156,14 @@
     <orderEntry type="library" exported="" scope="TEST" name="espresso-idling-resource-2.2.2" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-library-1.3" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-integration-1.3" level="project" />
-    <orderEntry type="library" exported="" name="recyclerview-v7-23.3.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="dexmaker-mockito-1.2" level="project" />
+    <orderEntry type="library" exported="" name="recyclerview-v7-23.3.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="mockito-core-1.9.5" level="project" />
-    <orderEntry type="library" exported="" name="cordova-5.1.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="jsr305-2.0.1" level="project" />
+    <orderEntry type="library" exported="" name="cordova-5.1.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="objenesis-1.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="espresso-core-2.2.2" level="project" />
+    <orderEntry type="library" exported="" name="seismic-1.0.2" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="exposed-instrumentation-api-publish-0.5" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="rules-0.5" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="javax.annotation-api-1.2" level="project" />
@@ -135,9 +174,6 @@
     <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="jsonassert-1.2.3" level="project" />
     <orderEntry type="library" exported="" name="okio-1.6.0" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="runner-0.4" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="exposed-instrumentation-api-publish-0.4" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="rules-0.4" level="project" />
     <orderEntry type="library" exported="" name="retrofit-2.0.2" level="project" />
     <orderEntry type="library" exported="" name="moshi-1.1.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-base-8.4.0" level="project" />
@@ -146,8 +182,8 @@
     <orderEntry type="library" exported="" name="play-services-gcm-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="okhttp-3.2.0" level="project" />
     <orderEntry type="library" exported="" name="support-v4-23.0.0" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="support-annotations-23.1.1" level="project" />
     <orderEntry type="library" exported="" name="play-services-basement-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.0.0" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="support-annotations-23.0.1" level="project" />
   </component>
 </module>

--- a/android/scaffold/scaffold.iml
+++ b/android/scaffold/scaffold.iml
@@ -43,6 +43,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/previewDisabledDebug/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/previewDisabled/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/previewDisabled/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/assets" type="java-test-resource" />
@@ -51,13 +58,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testPreviewDisabledDebug/shaders" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/previewDisabled/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/previewDisabled/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/previewDisabled/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/previewDisabled/assets" type="java-resource" />

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,3 @@
 include ':scaffold', ':astro', ':astro:pushclient'
-project(':astro').projectDir = new File(settingsDir, '../node_modules/astro-sdk/android')
-project(':astro:pushclient').projectDir = new File(settingsDir, '../node_modules/astro-sdk/node_modules/mobify-push-android-client/pushclient')
+project(':astro').projectDir = new File(settingsDir, '../node_modules/mobify-progressive-app-sdk/android')
+project(':astro:pushclient').projectDir = new File(settingsDir, '../node_modules/mobify-progressive-app-sdk/node_modules/mobify-push-android-client/pushclient')

--- a/ios/scaffold.xcworkspace/contents.xcworkspacedata
+++ b/ios/scaffold.xcworkspace/contents.xcworkspacedata
@@ -5,13 +5,13 @@
       location = "container:"
       name = "Astro">
       <FileRef
-         location = "group:../node_modules/astro-sdk/ios/Astro.xcodeproj">
+         location = "group:../node_modules/mobify-progressive-app-sdk/ios/Astro.xcodeproj">
       </FileRef>
       <FileRef
-         location = "group:../node_modules/astro-sdk/ios/vendor/CordovaLib/CordovaLib.xcodeproj">
+         location = "group:../node_modules/mobify-progressive-app-sdk/ios/vendor/CordovaLib/CordovaLib.xcodeproj">
       </FileRef>
       <FileRef
-         location = "group:../node_modules/astro-sdk/node_modules/mobify-push-ios-client/PushClient/PushClient.xcodeproj">
+         location = "group:../node_modules/mobify-progressive-app-sdk/node_modules/mobify-push-ios-client/PushClient/PushClient.xcodeproj">
       </FileRef>
    </Group>
    <FileRef

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "author": "Mobify",
   "dependencies": {
-    "astro-sdk": "mobify/astro#develop",
+    "mobify-progressive-app-sdk": "mobify/astro#develop",
     "babel-runtime": "^6.18.0",
     "bluebird": "~2.9.24",
     "grunt-requirejs": "^0.4.2",

--- a/scripts/build-dependencies.sh
+++ b/scripts/build-dependencies.sh
@@ -60,6 +60,6 @@ pushd $MYPATH/node_modules/mobify-progressive-app-sdk
 popd
 
 echo "Copying astro-client.js into app bundle"
-cp $MYPATH/node_modules/mobify-progressive-app-sdk/js/build/astro-client.js $MYPATH/app/app-www/js/build
+cp $MYPATH/node_modules/mobify-progressive-app-sdk/js/build/astro-client.js $MYPATH/app-www/js/build
 
 echo "SUCCESS: build dependencies"

--- a/scripts/build-dependencies.sh
+++ b/scripts/build-dependencies.sh
@@ -52,14 +52,14 @@ cp $MYPATH/node_modules/navitron/dist/navitron*.js $MYPATH/app-www/js/build
 cp $MYPATH/node_modules/jquery/dist/jquery.min.js $MYPATH/app-www/js/build
 cp $MYPATH/node_modules/bluebird/js/browser/bluebird*.js $MYPATH/app-www/js/build
 
-pushd $MYPATH/node_modules/astro-sdk
-    echo "Installing dependencies for astro-sdk"
+pushd $MYPATH/node_modules/mobify-progressive-app-sdk
+    echo "Installing dependencies for mobify-progressive-app-sdk"
     npm install --no-progress --no-spin $EXTRA_NPM_ARGS
     echo "Building astro-client.js"
     npm run build:astro_client
 popd
 
 echo "Copying astro-client.js into app bundle"
-cp $MYPATH/node_modules/astro-sdk/js/build/astro-client.js $MYPATH/app-www/js/build
+cp $MYPATH/node_modules/mobify-progressive-app-sdk/js/build/astro-client.js $MYPATH/app/app-www/js/build
 
 echo "SUCCESS: build dependencies"

--- a/webpack.app.config.js
+++ b/webpack.app.config.js
@@ -19,9 +19,9 @@ var config = {
     },
     resolve: {
         alias: {
-            astro: path.resolve(rootDir, 'node_modules/astro-sdk/js/src/'),
-            vendor: path.resolve(rootDir, 'node_modules/astro-sdk/js/vendor/'),
-            bluebird: path.resolve(rootDir, 'node_modules/astro-sdk/node_modules/bluebird')
+            astro: path.resolve(rootDir, 'node_modules/mobify-progressive-app-sdk/js/src/'),
+            vendor: path.resolve(rootDir, 'node_modules/mobify-progressive-app-sdk/js/vendor/'),
+            bluebird: path.resolve(rootDir, 'node_modules/mobify-progressive-app-sdk/node_modules/bluebird')
         }
     },
     plugins: [
@@ -47,7 +47,7 @@ var config = {
             test: /\.js$/,
             use: ['babel-loader'],
             include: [
-                path.resolve(rootDir, 'node_modules/astro-sdk/js'),
+                path.resolve(rootDir, 'node_modules/mobify-progressive-app-sdk/js'),
                 path.resolve(rootDir, 'app')
             ]
         }]


### PR DESCRIPTION
Use settings store instead of secure store to store welcome modal state. 
Update to use new astro location in npm

JIRA: None
Linked PRs: 

## Changes
- Update welcome modal to use settings store
- Change `astro-sdk` to `mobfiy-progressive-app-sdk` in all necessary files

## How to test-drive this PR
- Run apps in ios and android
- In app.js change `welcomeModalController.show({forced: **false**});` and ensure it is displayed the first time you open it but not the second time. (This doesn't work in the simulator according to some comments in the code)
- Test scaffold on "Cat in the Hat" Android device and ensure it runs.

## TODOS:
- [x] Change works in both Android and iOS.
- [x] CHANGELOG.md has been updated.
- [x] Run the generator to make sure it still functions correctly.
- [x] +1 from an engineer on the Astro team.
- [x] Both tab layout and drawer layout are fully functional in ios. (Set `useTabLayout` in `baseConfig`)
